### PR TITLE
Replace deprecated compare_and_swap with compare_exchange

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,9 +421,10 @@ impl Poller {
     /// ```
     pub fn notify(&self) -> io::Result<()> {
         log::trace!("Poller::notify()");
-        if !self
+        if self
             .notified
-            .compare_and_swap(false, true, Ordering::SeqCst)
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
         {
             self.poller.notify()?;
         }

--- a/src/wepoll.rs
+++ b/src/wepoll.rs
@@ -115,9 +115,10 @@ impl Poller {
     pub fn notify(&self) -> io::Result<()> {
         log::trace!("notify: handle={:?}", self.handle);
 
-        if !self
+        if self
             .notified
-            .compare_and_swap(false, true, Ordering::SeqCst)
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
         {
             unsafe {
                 // This call errors if a notification has already been posted, but that's okay - we


### PR DESCRIPTION
`compare_and_swap` is deprecated in 1.50. (https://github.com/rust-lang/rust/pull/79261)
This patch replaces the uses of `compare_and_swap` with `compare_exchange`.

See also the document about `compare_and_swap` -> `compare_exchange(_weak)` migration: https://doc.rust-lang.org/nightly/core/sync/atomic/struct.AtomicUsize.html#migrating-to-compare_exchange-and-compare_exchange_weak