### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ homepage = "https://github.com/smol-rs/polling"
 documentation = "https://docs.rs/polling"
 keywords = ["mio", "epoll", "kqueue", "iocp", "wepoll"]
 categories = ["asynchronous", "network-programming", "os"]
-readme = "README.md"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field.