### PR TITLE
Switch wepoll-sys to wepoll-ffi to reduce licenses used in dependency tree (discussed in #35)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ log = "0.4.11"
 libc = "0.2.77"
 
 [target.'cfg(windows)'.dependencies]
-wepoll-ffi = "0.1.0"
+wepoll-ffi = { version = "0.1.1", features = ["null-overlapped-wakeups-patch"] }
 winapi = { version = "0.3.9", features = ["ioapiset", "winsock2"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ log = "0.4.11"
 libc = "0.2.77"
 
 [target.'cfg(windows)'.dependencies]
-wepoll-ffi = { version = "0.1.1", features = ["null-overlapped-wakeups-patch"] }
+wepoll-ffi = { version = "0.1.2", features = ["null-overlapped-wakeups-patch"] }
 winapi = { version = "0.3.9", features = ["ioapiset", "winsock2"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ log = "0.4.11"
 libc = "0.2.77"
 
 [target.'cfg(windows)'.dependencies]
-wepoll-sys = "3.0.0"
+wepoll-ffi = "0.1.0"
 winapi = { version = "0.3.9", features = ["ioapiset", "winsock2"] }
 
 [dev-dependencies]

--- a/src/wepoll.rs
+++ b/src/wepoll.rs
@@ -7,7 +7,7 @@ use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
-use wepoll_sys as we;
+use wepoll_ffi as we;
 use winapi::ctypes;
 
 use crate::Event;
@@ -149,7 +149,7 @@ impl Poller {
             }
             we::epoll_event {
                 events: flags as u32,
-                data: we::epoll_data { u64: ev.key as u64 },
+                data: we::epoll_data { u64_: ev.key as u64 },
             }
         });
         wepoll!(epoll_ctl(
@@ -192,7 +192,7 @@ impl Events {
     pub fn new() -> Events {
         let ev = we::epoll_event {
             events: 0,
-            data: we::epoll_data { u64: 0 },
+            data: we::epoll_data { u64_: 0 },
         };
         Events {
             list: vec![ev; 1000].into_boxed_slice(),
@@ -203,7 +203,7 @@ impl Events {
     /// Iterates over I/O events.
     pub fn iter(&self) -> impl Iterator<Item = Event> + '_ {
         self.list[..self.len].iter().map(|ev| Event {
-            key: unsafe { ev.data.u64 } as usize,
+            key: unsafe { ev.data.u64_ } as usize,
             readable: (ev.events & READ_FLAGS) != 0,
             writable: (ev.events & WRITE_FLAGS) != 0,
         })


### PR DESCRIPTION
This PR is based on discussion in #35 and removes the only MPL-licensed dependency from the async-std dependency tree. All remaining licenses in it are very permissive (i.e. Apache-2.0/MIT or similar)

The new FFI bindings crate has been published to crates.io:
https://crates.io/crates/wepoll-ffi
https://github.com/aclysma/wepoll-ffi 

The main differences AFAIK from wepoll-sys:
 - bindgen by default named the "u64" fields in C as "u64_". I personally prefer sticking to bindgen's defaults unless there is reason not to (i.e. unusually awkward ergonomics).
 - This would effectively remove the patch discussed in https://github.com/piscisaureus/wepoll/pull/20 (meaning we would be using vanilla wepoll 1.5.8)

As discussed in #35, I would lean towards not including the patch as it has not been upstreamed to wepoll itself. But I'm happy to add it if we know it's needed.