### PR TITLE
Expose raw handles for the `Poller`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ std = []
 cfg-if = "1"
 log = "0.4.11"
 
+[build-dependencies]
+autocfg = "1"
+
 [target.'cfg(any(unix, target_os = "fuchsia", target_os = "vxworks"))'.dependencies]
 libc = "0.2.77"
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,16 @@
+fn main() {
+    let cfg = match autocfg::AutoCfg::new() {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            println!(
+                "cargo:warning=polling: failed to detect compiler features: {}",
+                e
+            );
+            return;
+        }
+    };
+
+    if !cfg.probe_rustc_version(1, 63) {
+        autocfg::emit("polling_no_io_safety");
+    }
+}

--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,11 @@ fn main() {
         }
     };
 
+    // We use "no_*" instead of "has_*" here. For non-Cargo
+    // build tools that don't run build.rs, the negative
+    // allows us to treat the current Rust version as the
+    // latest stable version, for when version information
+    // isn't available.
     if !cfg.probe_rustc_version(1, 63) {
         autocfg::emit("polling_no_io_safety");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@ cfg_if! {
     } else if #[cfg(any(
         target_os = "vxworks",
         target_os = "fuchsia",
+        target_os = "horizon",
         unix,
     ))] {
         mod poll;
@@ -438,6 +439,61 @@ impl Poller {
             self.poller.notify()?;
         }
         Ok(())
+    }
+}
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "illumos",
+    target_os = "solaris",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "dragonfly",
+))]
+mod raw_fd_impl {
+    use crate::Poller;
+    use std::os::unix::io::{AsRawFd, RawFd};
+
+    #[cfg(not(polling_no_io_safety))]
+    use std::os::unix::io::{AsFd, BorrowedFd};
+
+    impl AsRawFd for Poller {
+        fn as_raw_fd(&self) -> RawFd {
+            self.poller.as_raw_fd()
+        }
+    }
+
+    #[cfg(not(polling_no_io_safety))]
+    impl AsFd for Poller {
+        fn as_fd(&self) -> BorrowedFd<'_> {
+            self.poller.as_fd()
+        }
+    }
+}
+
+#[cfg(windows)]
+mod raw_handle_impl {
+    use crate::Poller;
+    use std::os::windows::io::{AsRawHandle, RawHandle};
+
+    #[cfg(not(polling_no_io_safety))]
+    use std::os::windows::io::{AsHandle, BorrowedHandle};
+
+    impl AsRawHandle for Poller {
+        fn as_raw_handle(&self) -> RawHandle {
+            self.poller.as_raw_handle()
+        }
+    }
+
+    #[cfg(not(polling_no_io_safety))]
+    impl AsHandle for Poller {
+        fn as_handle(&self) -> BorrowedHandle<'_> {
+            self.poller.as_handle()
+        }
     }
 }
 


### PR DESCRIPTION
Most of the current `Poller` instances are wrappers around either a `RawFd` or a `RawHandle`. For these platforms, an `AsRawFd` or `AsRawHandle` implementation is implemented on `Poller`. Then, because I have absolutely no self control, I also went ahead and conditionally implemented `AsFd` and `AsHandle` as well on conditionally proper Rust versions through `autocfg`. See sunfishcode/io-lifetimes#38 for more information.

This is part of my attempt at getting smol-rs/async-io#39 to work