### PR TITLE
Release 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 2.4.0
+
+- Fix the build error on illumos and Solaris (#43)
+- Bump MSRV to 1.47 (#40)
+- Optimize `Poller` internal representation (#40)
+
 # Version 2.3.0
 
 - Implement `AsRawFd` for `Poller` on most Unix systems (#39)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,15 +3,13 @@ name = "polling"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.3.0"
+version = "2.4.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.47"
 description = "Portable interface to epoll, kqueue, event ports, and wepoll"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/smol-rs/polling"
-homepage = "https://github.com/smol-rs/polling"
-documentation = "https://docs.rs/polling"
 keywords = ["mio", "epoll", "kqueue", "iocp", "wepoll"]
 categories = ["asynchronous", "network-programming", "os"]
 exclude = ["/.*"]


### PR DESCRIPTION
Changes:

- Fix the build error on illumos and Solaris (#43)
- Bump MSRV to 1.47 (#40)
- Optimize `Poller` internal representation (#40)