### PR TITLE
Test x86_64-pc-windows-gnu with Wine on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,18 @@ jobs:
         rustup target add x86_64-unknown-illumos
         cargo build --target x86_64-unknown-illumos
 
+  wine:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        run: rustup update stable
+      - uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: x86_64-pc-windows-gnu
+          runner: wine@7.13
+      - run: cargo test --target x86_64-pc-windows-gnu
+
   msrv:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Supported platforms:
   DragonFly BSD
 - [event ports](https://illumos.org/man/port_create): illumos, Solaris
 - [poll](https://en.wikipedia.org/wiki/Poll_(Unix)): VxWorks, Fuchsia, other Unix systems
-- [wepoll](https://github.com/piscisaureus/wepoll): Windows
+- [wepoll](https://github.com/piscisaureus/wepoll): Windows, Wine (version 7.13+)
 
 Polling is done in oneshot mode, which means interest in I/O events needs to be reset after
 an event is delivered if we're interested in the next event of the same kind.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //!   DragonFly BSD
 //! - [event ports](https://illumos.org/man/port_create): illumos, Solaris
 //! - [poll](https://en.wikipedia.org/wiki/Poll_(Unix)): VxWorks, Fuchsia, other Unix systems
-//! - [wepoll](https://github.com/piscisaureus/wepoll): Windows
+//! - [wepoll](https://github.com/piscisaureus/wepoll): Windows, Wine (version 7.13+)
 //!
 //! Polling is done in oneshot mode, which means interest in I/O events needs to be re-enabled
 //! after an event is delivered if we're interested in the next event of the same kind.


### PR DESCRIPTION
This adds test for x86_64-pc-windows-gnu with Wine 7.13 on CI.

This also documents that Wine 7.13+ is supported.

FYI, in 6.11-7.12 the following error occurs:

```
Error: Os { code: 66, kind: Uncategorized, message: "Bad device type." }
```

And, in pre-6.11 the following error occurs:

```
Error: Os { code: 10045, kind: Uncategorized, message: "OS Error 10045 (FormatMessageW() returned error 317)" }
```

cc #52
cc @notgull 