### PR TITLE
Add error message for Wepoll

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -18,4 +18,8 @@ fn main() {
     if !cfg.probe_rustc_version(1, 63) {
         autocfg::emit("polling_no_io_safety");
     }
+
+    if !cfg.probe_rustc_version(1, 53) {
+        autocfg::emit("polling_no_unsupported_error_kind");
+    }
 }

--- a/src/wepoll.rs
+++ b/src/wepoll.rs
@@ -43,7 +43,10 @@ impl Poller {
         let handle = unsafe { we::epoll_create1(0) };
         if handle.is_null() {
             return Err(io::Error::new(
+                #[cfg(not(polling_no_unsupported_error_kind))]
                 io::ErrorKind::Unsupported,
+                #[cfg(polling_no_unsupported_error_kind)]
+                io::ErrorKind::Other,
                 format!(
                     "Failed to initialize Wepoll: {}\nThis usually only happens for old Windows or Wine.",
                     io::Error::last_os_error()

--- a/src/wepoll.rs
+++ b/src/wepoll.rs
@@ -42,7 +42,13 @@ impl Poller {
     pub fn new() -> io::Result<Poller> {
         let handle = unsafe { we::epoll_create1(0) };
         if handle.is_null() {
-            return Err(io::Error::last_os_error());
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!(
+                    "Failed to initialize Wepoll: {}\nThis usually only happens for old Windows or Wine.",
+                    io::Error::last_os_error()
+                )
+            ));
         }
         let notified = AtomicBool::new(false);
         log::trace!("new: handle={:?}", handle);


### PR DESCRIPTION
This PR adds an error message for initialization of Wepoll that references Wine or an old Windows version. This should help users trying to debug why they are getting an error.