### PR TITLE
Release 2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 2.5.2
+
+- Update use of `libc::timespec` to prepare for future libc version (#55)
+- Update use of `libc::kevent` to prepare for future libc version (#56)
+- Add error message for Wepoll (#54)
+
 # Version 2.5.1
 
 - Fix the build error with MSRV on Windows

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "polling"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.5.1"
+version = "2.5.2"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.47"


### PR DESCRIPTION
Changes:

- Update use of `libc::timespec` to prepare for future libc version (#55)
- Update use of `libc::kevent` to prepare for future libc version (#56)
- Add error message for Wepoll (#54)

Closes #57 