### PR TITLE
Add level and edge triggered modes to the poller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /target
 Cargo.lock
-/.vscode

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 #[cfg(not(polling_no_io_safety))]
 use std::os::unix::io::{AsFd, BorrowedFd};
 
-use crate::Event;
+use crate::{Event, PollMode};
 
 /// Interface to kqueue.
 #[derive(Debug)]
@@ -47,6 +47,7 @@ impl Poller {
                 readable: true,
                 writable: false,
             },
+            PollMode::Oneshot,
         )?;
 
         log::trace!(
@@ -57,25 +58,41 @@ impl Poller {
         Ok(poller)
     }
 
+    /// Whether this poller supports level-triggered events.
+    pub fn supports_level(&self) -> bool {
+        true
+    }
+
+    /// Whether this poller supports edge-triggered events.
+    pub fn supports_edge(&self) -> bool {
+        true
+    }
+
     /// Adds a new file descriptor.
-    pub fn add(&self, fd: RawFd, ev: Event) -> io::Result<()> {
+    pub fn add(&self, fd: RawFd, ev: Event, mode: PollMode) -> io::Result<()> {
         // File descriptors don't need to be added explicitly, so just modify the interest.
-        self.modify(fd, ev)
+        self.modify(fd, ev, mode)
     }
 
     /// Modifies an existing file descriptor.
-    pub fn modify(&self, fd: RawFd, ev: Event) -> io::Result<()> {
+    pub fn modify(&self, fd: RawFd, ev: Event, mode: PollMode) -> io::Result<()> {
         if fd != self.read_stream.as_raw_fd() {
             log::trace!("add: kqueue_fd={}, fd={}, ev={:?}", self.kqueue_fd, fd, ev);
         }
 
+        let mode_flags = match mode {
+            PollMode::Oneshot => libc::EV_ONESHOT,
+            PollMode::Level => 0,
+            PollMode::Edge => libc::EV_DISPATCH,
+        };
+
         let read_flags = if ev.readable {
-            libc::EV_ADD | libc::EV_ONESHOT
+            libc::EV_ADD | mode_flags
         } else {
             libc::EV_DELETE
         };
         let write_flags = if ev.writable {
-            libc::EV_ADD | libc::EV_ONESHOT
+            libc::EV_ADD | mode_flags
         } else {
             libc::EV_DELETE
         };
@@ -127,7 +144,7 @@ impl Poller {
     /// Deletes a file descriptor.
     pub fn delete(&self, fd: RawFd) -> io::Result<()> {
         // Simply delete interest in the file descriptor.
-        self.modify(fd, Event::none(0))
+        self.modify(fd, Event::none(0), PollMode::Oneshot)
     }
 
     /// Waits for I/O events with an optional timeout.
@@ -166,6 +183,7 @@ impl Poller {
                 readable: true,
                 writable: false,
             },
+            PollMode::Oneshot,
         )?;
 
         Ok(())

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -83,7 +83,7 @@ impl Poller {
         let mode_flags = match mode {
             PollMode::Oneshot => libc::EV_ONESHOT,
             PollMode::Level => 0,
-            PollMode::Edge => libc::EV_DISPATCH,
+            PollMode::Edge => libc::EV_CLEAR,
         };
 
         let read_flags = if ev.readable {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,16 +388,21 @@ impl Poller {
         self.modify_with_mode(source, interest, PollMode::Oneshot)
     }
 
-    /// Modifies interest in a file descriptor or socket to the poller, but with the
-    /// specified mode.
+    /// Modifies interest in a file descriptor or socket to the poller, but with the specified
+    /// mode.
     ///
-    /// This is identical to the `modify()` function, but allows specifying the
-    /// polling mode to use for this socket.
+    /// This is identical to the `modify()` function, but allows specifying the polling mode
+    /// to use for this socket.
+    ///
+    /// # Performance Notes
+    ///
+    /// This function can be used to change a source from one polling mode to another. However,
+    /// on some platforms, this switch can cause delays in the delivery of events.
     ///
     /// # Errors
     ///
-    /// If the operating system does not support the specified mode, this function
-    /// will return an error.
+    /// If the operating system does not support the specified mode, this function will return
+    /// an error.
     pub fn modify_with_mode(
         &self,
         source: impl Source,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -652,3 +652,14 @@ cfg_if! {
         }
     }
 }
+
+#[allow(unused)]
+fn unsupported_error(err: impl Into<String>) -> io::Error {
+    io::Error::new(
+        #[cfg(not(polling_no_unsupported_error_kind))]
+        io::ErrorKind::Unsupported,
+        #[cfg(polling_no_unsupported_error_kind)]
+        io::ErrorKind::Other,
+        err.into(),
+    )
+}

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant};
 // std::os::unix doesn't exist on Fuchsia
 use libc::c_int as RawFd;
 
-use crate::Event;
+use crate::{Event, PollMode};
 
 /// Interface to poll.
 #[derive(Debug)]
@@ -77,6 +77,8 @@ struct FdData {
     poll_fds_index: usize,
     /// The key of the `Event` associated with this file descriptor.
     key: usize,
+    /// Whether to remove this file descriptor from the poller on the next call to `wait`.
+    remove: bool,
 }
 
 impl Poller {
@@ -117,8 +119,18 @@ impl Poller {
         })
     }
 
+    /// Whether this poller supports level-triggered events.
+    pub fn supports_level(&self) -> bool {
+        true
+    }
+
+    /// Whether the poller supports edge-triggered events.
+    pub fn supports_edge(&self) -> bool {
+        false
+    }
+
     /// Adds a new file descriptor.
-    pub fn add(&self, fd: RawFd, ev: Event) -> io::Result<()> {
+    pub fn add(&self, fd: RawFd, ev: Event, mode: PollMode) -> io::Result<()> {
         if fd == self.notify_read || fd == self.notify_write {
             return Err(io::Error::from(io::ErrorKind::InvalidInput));
         }
@@ -141,6 +153,19 @@ impl Poller {
                 FdData {
                     poll_fds_index,
                     key: ev.key,
+                    remove: match mode {
+                        PollMode::Oneshot => true,
+                        PollMode::Level => false,
+                        PollMode::Edge => {
+                            return Err(io::Error::new(
+                                #[cfg(not(polling_no_unsupported_error_kind))]
+                                io::ErrorKind::Unsupported,
+                                #[cfg(polling_no_unsupported_error_kind)]
+                                io::ErrorKind::Other,
+                                "edge-triggered events are not supported with poll()",
+                            ))
+                        }
+                    },
                 },
             );
 
@@ -155,7 +180,7 @@ impl Poller {
     }
 
     /// Modifies an existing file descriptor.
-    pub fn modify(&self, fd: RawFd, ev: Event) -> io::Result<()> {
+    pub fn modify(&self, fd: RawFd, ev: Event, mode: PollMode) -> io::Result<()> {
         log::trace!(
             "modify: notify_read={}, fd={}, ev={:?}",
             self.notify_read,
@@ -168,6 +193,19 @@ impl Poller {
             data.key = ev.key;
             let poll_fds_index = data.poll_fds_index;
             fds.poll_fds[poll_fds_index].0.events = poll_events(ev);
+            data.remove = match mode {
+                PollMode::Oneshot => true,
+                PollMode::Level => false,
+                PollMode::Edge => {
+                    return Err(io::Error::new(
+                        #[cfg(not(polling_no_unsupported_error_kind))]
+                        io::ErrorKind::Unsupported,
+                        #[cfg(polling_no_unsupported_error_kind)]
+                        io::ErrorKind::Other,
+                        "edge-triggered events are not supported with poll()",
+                    ))
+                }
+            };
 
             Ok(())
         })
@@ -257,8 +295,10 @@ impl Poller {
                             readable: poll_fd.revents & READ_REVENTS != 0,
                             writable: poll_fd.revents & WRITE_REVENTS != 0,
                         });
-                        // Remove interest
-                        poll_fd.events = 0;
+                        // Remove interest if necessary
+                        if fd_data.remove {
+                            poll_fd.events = 0;
+                        }
 
                         if events.inner.len() == num_fd_events {
                             break;
@@ -299,7 +339,7 @@ impl Poller {
             let _ = self.pop_notification();
         }
 
-        let res = f(&mut *fds);
+        let res = f(&mut fds);
 
         if self.waiting_operations.fetch_sub(1, Ordering::SeqCst) == 1 {
             self.operations_complete.notify_one();

--- a/src/port.rs
+++ b/src/port.rs
@@ -79,11 +79,7 @@ impl Poller {
         }
 
         if let PollMode::Edge | PollMode::Level = mode {
-            return Err(io::Error::new(
-                #[cfg(not(polling_no_unsupported_error_kind))]
-                io::ErrorKind::Unsupported,
-                #[cfg(polling_no_unsupported_error_kind)]
-                io::ErrorKind::Other,
+            return Err(crate::unsupported_error(
                 "this kind of event is not supported with event ports",
             ));
         }

--- a/src/wepoll.rs
+++ b/src/wepoll.rs
@@ -42,11 +42,7 @@ impl Poller {
     pub fn new() -> io::Result<Poller> {
         let handle = unsafe { we::epoll_create1(0) };
         if handle.is_null() {
-            return Err(io::Error::new(
-                #[cfg(not(polling_no_unsupported_error_kind))]
-                io::ErrorKind::Unsupported,
-                #[cfg(polling_no_unsupported_error_kind)]
-                io::ErrorKind::Other,
+            return Err(crate::unsupported_error(
                 format!(
                     "Failed to initialize Wepoll: {}\nThis usually only happens for old Windows or Wine.",
                     io::Error::last_os_error()
@@ -167,13 +163,9 @@ impl Poller {
                     PollMode::Level => 0,
                     PollMode::Oneshot => we::EPOLLONESHOT,
                     PollMode::Edge => {
-                        return Err(io::Error::new(
-                            #[cfg(not(polling_no_unsupported_error_kind))]
-                            io::ErrorKind::Unsupported,
-                            #[cfg(polling_no_unsupported_error_kind)]
-                            io::ErrorKind::Other,
+                        return Err(crate::unsupported_error(
                             "edge-triggered events are not supported with wepoll",
-                        ))
+                        ));
                     }
                 };
                 if ev.readable {

--- a/tests/other_modes.rs
+++ b/tests/other_modes.rs
@@ -1,0 +1,170 @@
+//! Tests for level triggered and edge triggered mode.
+
+#![allow(clippy::unused_io_amount)]
+
+use std::io::{self, prelude::*};
+use std::net::{TcpListener, TcpStream};
+use std::time::Duration;
+
+use polling::{Event, PollMode, Poller};
+
+#[test]
+fn level_triggered() {
+    // Create our streams.
+    let (mut reader, mut writer) = tcp_pair().unwrap();
+    let reader_token = 1;
+
+    // Create our poller and register our streams.
+    let poller = Poller::new().unwrap();
+    if poller
+        .add_with_mode(&reader, Event::readable(reader_token), PollMode::Level)
+        .is_err()
+    {
+        // Only panic if we're on a platform that should support level mode.
+        cfg_if::cfg_if! {
+            if #[cfg(any(target_os = "solaris", target_os = "illumos"))] {
+                return;
+            } else {
+                panic!("Level mode should be supported on this platform");
+            }
+        }
+    }
+
+    // Write some data to the writer.
+    let data = [1, 2, 3, 4, 5];
+    writer.write_all(&data).unwrap();
+
+    // A "readable" notification should be delivered.
+    let mut events = Vec::new();
+    poller
+        .wait(&mut events, Some(Duration::from_secs(10)))
+        .unwrap();
+
+    assert_eq!(events, [Event::readable(reader_token)]);
+
+    // If we read some of the data, the notification should still be available.
+    reader.read_exact(&mut [0; 3]).unwrap();
+    events.clear();
+    poller
+        .wait(&mut events, Some(Duration::from_secs(10)))
+        .unwrap();
+    assert_eq!(events, [Event::readable(reader_token)]);
+
+    // If we read the rest of the data, the notification should be gone.
+    reader.read_exact(&mut [0; 2]).unwrap();
+    events.clear();
+    poller
+        .wait(&mut events, Some(Duration::from_secs(0)))
+        .unwrap();
+
+    assert_eq!(events, []);
+
+    // After modifying the stream and sending more data, it should be oneshot.
+    poller
+        .modify_with_mode(&reader, Event::readable(reader_token), PollMode::Oneshot)
+        .unwrap();
+
+    writer.write(&data).unwrap();
+    events.clear();
+
+    // BUG: Somehow, the notification here is delayed?
+    poller
+        .wait(&mut events, Some(Duration::from_secs(10)))
+        .unwrap();
+
+    assert_eq!(events, [Event::readable(reader_token)]);
+
+    // After reading, the notification should vanish.
+    reader.read(&mut [0; 5]).unwrap();
+    events.clear();
+    poller
+        .wait(&mut events, Some(Duration::from_secs(0)))
+        .unwrap();
+
+    assert_eq!(events, []);
+}
+
+#[test]
+fn edge_triggered() {
+    // Create our streams.
+    let (mut reader, mut writer) = tcp_pair().unwrap();
+    let reader_token = 1;
+
+    // Create our poller and register our streams.
+    let poller = Poller::new().unwrap();
+    if poller
+        .add_with_mode(&reader, Event::readable(reader_token), PollMode::Edge)
+        .is_err()
+    {
+        // Only panic if we're on a platform that should support level mode.
+        cfg_if::cfg_if! {
+            if #[cfg(all(
+                any(
+                    target_os = "linux",
+                    target_os = "android",
+                    target_os = "macos",
+                    target_os = "ios",
+                    target_os = "tvos",
+                    target_os = "watchos",
+                    target_os = "freebsd",
+                    target_os = "netbsd",
+                    target_os = "openbsd",
+                    target_os = "dragonfly"
+                ),
+                not(polling_test_poll_backend)
+            ))] {
+                panic!("Edge mode should be supported on this platform");
+            } else {
+                return;
+            }
+        }
+    }
+
+    // Write some data to the writer.
+    let data = [1, 2, 3, 4, 5];
+    writer.write_all(&data).unwrap();
+
+    // A "readable" notification should be delivered.
+    let mut events = Vec::new();
+    poller
+        .wait(&mut events, Some(Duration::from_secs(10)))
+        .unwrap();
+
+    assert_eq!(events, [Event::readable(reader_token)]);
+
+    // If we read some of the data, the notification should not still be available.
+    reader.read_exact(&mut [0; 3]).unwrap();
+    events.clear();
+    poller
+        .wait(&mut events, Some(Duration::from_secs(0)))
+        .unwrap();
+    assert_eq!(events, []);
+
+    // If we write more data, a notification should be delivered.
+    writer.write_all(&data).unwrap();
+    events.clear();
+    poller
+        .wait(&mut events, Some(Duration::from_secs(10)))
+        .unwrap();
+    assert_eq!(events, [Event::readable(reader_token)]);
+
+    // After modifying the stream and sending more data, it should be oneshot.
+    poller
+        .modify_with_mode(&reader, Event::readable(reader_token), PollMode::Oneshot)
+        .unwrap();
+
+    writer.write_all(&data).unwrap();
+    events.clear();
+    poller
+        .wait(&mut events, Some(Duration::from_secs(10)))
+        .unwrap();
+
+    assert_eq!(events, [Event::readable(reader_token)]);
+}
+
+fn tcp_pair() -> io::Result<(TcpStream, TcpStream)> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let a = TcpStream::connect(listener.local_addr()?)?;
+    let (b, _) = listener.accept()?;
+    Ok((a, b))
+}


### PR DESCRIPTION
At the moment, `polling` only supports oneshot-triggered event polling. However, most of the backends `polling` uses also supports level-triggered operation and some even support edge-triggered operations. While oneshot polling works for the `async-io` usecase, other users may want to use other polling modes. This PR adds alternative polling modes and avenues to use to react if one isn't available.

Note that we *may* be able to support level-triggered operation on Solarish, with some extra elbow grease. However, unless there's another way I couldn't see, the only way I could see to do this would be to keep track of the level-trigger file descriptors through a `HashSet` (wrapped in a `Mutex`) and that would add some performance burden to the polling operation.