### PR TITLE
Test the backend that uses poll on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,12 @@ jobs:
         uses: taiki-e/install-action@cargo-hack
       - run: cargo build --all --all-features --all-targets
       - run: cargo test
+      - run: cargo test
+        env:
+          # Note: This cfg is intended to make it easy for polling developers to test
+          # the backend that uses poll, and is not a public API.
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} --cfg polling_test_poll_backend
+        if: startsWith(matrix.os, 'ubuntu')
       - run: cargo hack build --feature-powerset --no-dev-deps
       - name: Clone async-io
         run: git clone https://github.com/smol-rs/async-io.git

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,12 @@ macro_rules! syscall {
 }
 
 cfg_if! {
-    if #[cfg(any(target_os = "linux", target_os = "android"))] {
+    // Note: This cfg is intended to make it easy for polling developers to test
+    // the backend that uses poll, and is not a public API.
+    if #[cfg(polling_test_poll_backend)] {
+        mod poll;
+        use poll as sys;
+    } else if #[cfg(any(target_os = "linux", target_os = "android"))] {
         mod epoll;
         use epoll as sys;
     } else if #[cfg(any(
@@ -445,19 +450,22 @@ impl Poller {
     }
 }
 
-#[cfg(any(
-    target_os = "linux",
-    target_os = "android",
-    target_os = "illumos",
-    target_os = "solaris",
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "tvos",
-    target_os = "watchos",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "dragonfly",
+#[cfg(all(
+    any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "illumos",
+        target_os = "solaris",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "dragonfly",
+    ),
+    not(polling_test_poll_backend),
 ))]
 #[cfg_attr(
     docsrs,

--- a/tests/precision.rs
+++ b/tests/precision.rs
@@ -22,17 +22,20 @@ fn below_ms() -> io::Result<()> {
         lowest = lowest.min(elapsed);
     }
 
-    if cfg!(any(
-        target_os = "linux",
-        target_os = "android",
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "tvos",
-        target_os = "watchos",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "dragonfly",
+    if cfg!(all(
+        any(
+            target_os = "linux",
+            target_os = "android",
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "watchos",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            target_os = "dragonfly",
+        ),
+        not(polling_test_poll_backend)
     )) {
         assert!(lowest < dur + margin);
     }
@@ -58,19 +61,22 @@ fn above_ms() -> io::Result<()> {
         lowest = lowest.min(elapsed);
     }
 
-    if cfg!(any(
-        target_os = "linux",
-        target_os = "android",
-        target_os = "illumos",
-        target_os = "solaris",
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "tvos",
-        target_os = "watchos",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "dragonfly",
+    if cfg!(all(
+        any(
+            target_os = "linux",
+            target_os = "android",
+            target_os = "illumos",
+            target_os = "solaris",
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "watchos",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            target_os = "dragonfly",
+        ),
+        not(polling_test_poll_backend)
     )) {
         assert!(lowest < dur + margin);
     }


### PR DESCRIPTION
This backend (https://github.com/smol-rs/polling/pull/26) is only used on minor operating systems which is not easy for us to test.

Historically we used to do these tests by adjusting cfg on Linux or macOS. (https://github.com/smol-rs/polling/pull/26#issue-770294269, https://github.com/smol-rs/polling/pull/26#pullrequestreview-741004153)

This patch makes testing in such a way easy and can be run on CI.