### PR TITLE
int: Use tracing instead of log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ std = []
 
 [dependencies]
 cfg-if = "1"
-log = "0.4.11"
+tracing = { version = "0.1.37", default-features = false }
 
 [build-dependencies]
 autocfg = "1"

--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -79,7 +79,7 @@ impl Poller {
             },
         )?;
 
-        log::trace!(
+        tracing::trace!(
             "new: epoll_fd={}, event_fd={}, timer_fd={:?}",
             epoll_fd,
             event_fd,
@@ -90,25 +90,25 @@ impl Poller {
 
     /// Adds a new file descriptor.
     pub fn add(&self, fd: RawFd, ev: Event) -> io::Result<()> {
-        log::trace!("add: epoll_fd={}, fd={}, ev={:?}", self.epoll_fd, fd, ev);
+        tracing::trace!("add: epoll_fd={}, fd={}, ev={:?}", self.epoll_fd, fd, ev);
         self.ctl(libc::EPOLL_CTL_ADD, fd, Some(ev))
     }
 
     /// Modifies an existing file descriptor.
     pub fn modify(&self, fd: RawFd, ev: Event) -> io::Result<()> {
-        log::trace!("modify: epoll_fd={}, fd={}, ev={:?}", self.epoll_fd, fd, ev);
+        tracing::trace!("modify: epoll_fd={}, fd={}, ev={:?}", self.epoll_fd, fd, ev);
         self.ctl(libc::EPOLL_CTL_MOD, fd, Some(ev))
     }
 
     /// Deletes a file descriptor.
     pub fn delete(&self, fd: RawFd) -> io::Result<()> {
-        log::trace!("remove: epoll_fd={}, fd={}", self.epoll_fd, fd);
+        tracing::trace!("remove: epoll_fd={}, fd={}", self.epoll_fd, fd);
         self.ctl(libc::EPOLL_CTL_DEL, fd, None)
     }
 
     /// Waits for I/O events with an optional timeout.
     pub fn wait(&self, events: &mut Events, timeout: Option<Duration>) -> io::Result<()> {
-        log::trace!("wait: epoll_fd={}, timeout={:?}", self.epoll_fd, timeout);
+        tracing::trace!("wait: epoll_fd={}, timeout={:?}", self.epoll_fd, timeout);
 
         if let Some(timer_fd) = self.timer_fd {
             // Configure the timeout using timerfd.
@@ -165,7 +165,7 @@ impl Poller {
             timeout_ms as libc::c_int,
         ))?;
         events.len = res as usize;
-        log::trace!("new events: epoll_fd={}, res={}", self.epoll_fd, res);
+        tracing::trace!("new events: epoll_fd={}, res={}", self.epoll_fd, res);
 
         // Clear the notification (if received) and re-register interest in it.
         let mut buf = [0u8; 8];
@@ -187,7 +187,7 @@ impl Poller {
 
     /// Sends a notification to wake up the current or next `wait()` call.
     pub fn notify(&self) -> io::Result<()> {
-        log::trace!(
+        tracing::trace!(
             "notify: epoll_fd={}, event_fd={}",
             self.epoll_fd,
             self.event_fd
@@ -245,7 +245,7 @@ impl AsFd for Poller {
 
 impl Drop for Poller {
     fn drop(&mut self) {
-        log::trace!(
+        tracing::trace!(
             "drop: epoll_fd={}, event_fd={}, timer_fd={:?}",
             self.epoll_fd,
             self.event_fd,

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -49,7 +49,7 @@ impl Poller {
             },
         )?;
 
-        log::trace!(
+        tracing::trace!(
             "new: kqueue_fd={}, read_stream={:?}",
             kqueue_fd,
             poller.read_stream
@@ -66,7 +66,7 @@ impl Poller {
     /// Modifies an existing file descriptor.
     pub fn modify(&self, fd: RawFd, ev: Event) -> io::Result<()> {
         if fd != self.read_stream.as_raw_fd() {
-            log::trace!("add: kqueue_fd={}, fd={}, ev={:?}", self.kqueue_fd, fd, ev);
+            tracing::trace!("add: kqueue_fd={}, fd={}, ev={:?}", self.kqueue_fd, fd, ev);
         }
 
         let read_flags = if ev.readable {
@@ -132,7 +132,7 @@ impl Poller {
 
     /// Waits for I/O events with an optional timeout.
     pub fn wait(&self, events: &mut Events, timeout: Option<Duration>) -> io::Result<()> {
-        log::trace!("wait: kqueue_fd={}, timeout={:?}", self.kqueue_fd, timeout);
+        tracing::trace!("wait: kqueue_fd={}, timeout={:?}", self.kqueue_fd, timeout);
 
         // Convert the `Duration` to `libc::timespec`.
         let timeout = timeout.map(|t| libc::timespec {
@@ -155,7 +155,7 @@ impl Poller {
             }
         ))?;
         events.len = res as usize;
-        log::trace!("new events: kqueue_fd={}, res={}", self.kqueue_fd, res);
+        tracing::trace!("new events: kqueue_fd={}, res={}", self.kqueue_fd, res);
 
         // Clear the notification (if received) and re-register interest in it.
         while (&self.read_stream).read(&mut [0; 64]).is_ok() {}
@@ -173,7 +173,7 @@ impl Poller {
 
     /// Sends a notification to wake up the current or next `wait()` call.
     pub fn notify(&self) -> io::Result<()> {
-        log::trace!("notify: kqueue_fd={}", self.kqueue_fd);
+        tracing::trace!("notify: kqueue_fd={}", self.kqueue_fd);
         let _ = (&self.write_stream).write(&[1]);
         Ok(())
     }
@@ -195,7 +195,7 @@ impl AsFd for Poller {
 
 impl Drop for Poller {
     fn drop(&mut self) {
-        log::trace!("drop: kqueue_fd={}", self.kqueue_fd);
+        tracing::trace!("drop: kqueue_fd={}", self.kqueue_fd);
         let _ = self.delete(self.read_stream.as_raw_fd());
         let _ = syscall!(close(self.kqueue_fd));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,7 +396,8 @@ impl Poller {
     /// # std::io::Result::Ok(())
     /// ```
     pub fn wait(&self, events: &mut Vec<Event>, timeout: Option<Duration>) -> io::Result<usize> {
-        log::trace!("Poller::wait(_, {:?})", timeout);
+        let span = tracing::trace_span!("Poller::wait", timeout = ?timeout);
+        let _enter = span.enter();
 
         if let Ok(mut lock) = self.events.try_lock() {
             // Wait for I/O events.
@@ -410,7 +411,7 @@ impl Poller {
             events.extend(lock.iter().filter(|ev| ev.key != usize::MAX));
             Ok(events.len() - len)
         } else {
-            log::trace!("wait: skipping because another thread is already waiting on I/O");
+            tracing::trace!("wait: skipping because another thread is already waiting on I/O");
             Ok(0)
         }
     }
@@ -438,7 +439,9 @@ impl Poller {
     /// # std::io::Result::Ok(())
     /// ```
     pub fn notify(&self) -> io::Result<()> {
-        log::trace!("Poller::notify()");
+        let span = tracing::trace_span!("Poller::notify");
+        let _enter = span.enter();
+
         if self
             .notified
             .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)

--- a/src/wepoll.rs
+++ b/src/wepoll.rs
@@ -54,19 +54,19 @@ impl Poller {
             ));
         }
         let notified = AtomicBool::new(false);
-        log::trace!("new: handle={:?}", handle);
+        tracing::trace!("new: handle={:?}", handle);
         Ok(Poller { handle, notified })
     }
 
     /// Adds a socket.
     pub fn add(&self, sock: RawSocket, ev: Event) -> io::Result<()> {
-        log::trace!("add: handle={:?}, sock={}, ev={:?}", self.handle, sock, ev);
+        tracing::trace!("add: handle={:?}, sock={}, ev={:?}", self.handle, sock, ev);
         self.ctl(we::EPOLL_CTL_ADD, sock, Some(ev))
     }
 
     /// Modifies a socket.
     pub fn modify(&self, sock: RawSocket, ev: Event) -> io::Result<()> {
-        log::trace!(
+        tracing::trace!(
             "modify: handle={:?}, sock={}, ev={:?}",
             self.handle,
             sock,
@@ -77,7 +77,7 @@ impl Poller {
 
     /// Deletes a socket.
     pub fn delete(&self, sock: RawSocket) -> io::Result<()> {
-        log::trace!("remove: handle={:?}, sock={}", self.handle, sock);
+        tracing::trace!("remove: handle={:?}, sock={}", self.handle, sock);
         self.ctl(we::EPOLL_CTL_DEL, sock, None)
     }
 
@@ -88,7 +88,7 @@ impl Poller {
     /// If a notification occurs, this method will return but the notification event will not be
     /// included in the `events` list nor contribute to the returned count.
     pub fn wait(&self, events: &mut Events, timeout: Option<Duration>) -> io::Result<()> {
-        log::trace!("wait: handle={:?}, timeout={:?}", self.handle, timeout);
+        tracing::trace!("wait: handle={:?}, timeout={:?}", self.handle, timeout);
         let deadline = timeout.map(|t| Instant::now() + t);
 
         loop {
@@ -112,7 +112,7 @@ impl Poller {
                 events.list.len() as c_int,
                 timeout_ms,
             ))? as usize;
-            log::trace!("new events: handle={:?}, len={}", self.handle, events.len);
+            tracing::trace!("new events: handle={:?}, len={}", self.handle, events.len);
 
             // Break if there was a notification or at least one event, or if deadline is reached.
             if self.notified.swap(false, Ordering::SeqCst) || events.len > 0 || timeout_ms == 0 {
@@ -125,7 +125,7 @@ impl Poller {
 
     /// Sends a notification to wake up the current or next `wait()` call.
     pub fn notify(&self) -> io::Result<()> {
-        log::trace!("notify: handle={:?}", self.handle);
+        tracing::trace!("notify: handle={:?}", self.handle);
 
         if self
             .notified
@@ -194,7 +194,7 @@ impl AsHandle for Poller {
 
 impl Drop for Poller {
     fn drop(&mut self) {
-        log::trace!("drop: handle={:?}", self.handle);
+        tracing::trace!("drop: handle={:?}", self.handle);
         unsafe {
             we::epoll_close(self.handle);
         }


### PR DESCRIPTION
See [this comment](https://github.com/smol-rs/blocking/pull/31#discussion_r1059248293). This PR replaces `log` with `tracing`.