### PR TITLE
bugfix: Prevent large timeouts from causing panics

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -213,7 +213,7 @@ impl Poller {
             timeout
         );
 
-        let deadline = timeout.map(|t| Instant::now() + t);
+        let deadline = timeout.and_then(|t| Instant::now().checked_add(t));
 
         events.inner.clear();
 

--- a/src/wepoll.rs
+++ b/src/wepoll.rs
@@ -95,7 +95,7 @@ impl Poller {
     /// included in the `events` list nor contribute to the returned count.
     pub fn wait(&self, events: &mut Events, timeout: Option<Duration>) -> io::Result<()> {
         log::trace!("wait: handle={:?}, timeout={:?}", self.handle, timeout);
-        let deadline = timeout.map(|t| Instant::now() + t);
+        let deadline = timeout.and_then(|t| Instant::now().checked_add(t));
 
         loop {
             // Convert the timeout to milliseconds.


### PR DESCRIPTION
This prevents large timeouts from causing panics in `wait()`. Similar to smol-rs/async-io#87