### PR TITLE
Test NetBSD/OpenBSD/Dragonfly BSD with vmactions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,7 +21,7 @@ freebsd_task:
       env:
         TARGET: i686-unknown-freebsd
   setup_script:
-    - pkg install -y bash git
+    - pkg install -y git
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable --target $TARGET
   test_script:
     - . $HOME/.cargo/env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,12 +76,6 @@ jobs:
     - name: Android
       if: startsWith(matrix.os, 'ubuntu')
       run: cross test --target arm-linux-androideabi
-    - name: NetBSD
-      if: startsWith(matrix.os, 'ubuntu')
-      run: cross build --target x86_64-unknown-netbsd
-    - name: FreeBSD
-      if: startsWith(matrix.os, 'ubuntu')
-      run: cross build --target x86_64-unknown-freebsd
     - name: iOS
       if: startsWith(matrix.os, 'macos')
       run: cross build --target aarch64-apple-ios
@@ -98,6 +92,55 @@ jobs:
       run: |
         rustup target add x86_64-unknown-illumos
         cargo build --target x86_64-unknown-illumos
+
+  netbsd:
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test NetBSD
+      id: test
+      uses: vmactions/netbsd-vm@v0
+      with:
+        envs: CARGO_INCREMENTAL CARGO_NET_GIT_FETCH_WITH_CLI CARGO_NET_RETRY RUST_BACKTRACE RUSTFLAGS RUSTDOCFLAGS RUSTUP_MAX_RETRIES
+        usesh: true
+        prepare: |
+          pkg_add curl git
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
+        run: |
+          . $HOME/.cargo/env
+          cargo test
+
+  openbsd:
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test OpenBSD
+      id: test
+      uses: vmactions/openbsd-vm@v0
+      with:
+        envs: CARGO_INCREMENTAL CARGO_NET_GIT_FETCH_WITH_CLI CARGO_NET_RETRY RUST_BACKTRACE RUSTFLAGS RUSTDOCFLAGS RUSTUP_MAX_RETRIES
+        usesh: true
+        # OpenBSD is tier 3 target, so install rust from package manager instead of rustup
+        prepare: |
+          pkg_add git rust
+        run: |
+          cargo test
+
+  dragonfly:
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test Dragonfly BSD
+      id: test
+      uses: vmactions/dragonflybsd-vm@v0
+      with:
+        envs: CARGO_INCREMENTAL CARGO_NET_GIT_FETCH_WITH_CLI CARGO_NET_RETRY RUST_BACKTRACE RUSTFLAGS RUSTDOCFLAGS RUSTUP_MAX_RETRIES
+        usesh: true
+        # Dragonfly BSD is tier 3 target, so install rust from package manager instead of rustup
+        prepare: |
+          pkg install -y rust
+        run: |
+          cargo test
 
   wine:
     runs-on: ubuntu-22.04

--- a/tests/precision.rs
+++ b/tests/precision.rs
@@ -31,9 +31,6 @@ fn below_ms() -> io::Result<()> {
             target_os = "tvos",
             target_os = "watchos",
             target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd",
-            target_os = "dragonfly",
         ),
         not(polling_test_poll_backend)
     )) {
@@ -72,9 +69,6 @@ fn above_ms() -> io::Result<()> {
             target_os = "tvos",
             target_os = "watchos",
             target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd",
-            target_os = "dragonfly",
         ),
         not(polling_test_poll_backend)
     )) {


### PR DESCRIPTION
Refs: https://github.com/vmactions

Also fixes tests failing on these platforms.

Closes #75

As a concern, vmactions is slow and also not very stable. (Ideally, I would like to use a faster and more stable VM like #77 for FreeBSD, but Cirrus CI doesn't support these platforms.) So if these start to fail, we may need to consider removing them.

(Btw vmactions also supports Solaris, but it takes about 20 minutes to set up the VM...)