### PR TITLE
Use the try-iter method from concurrent-queue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ libc = "0.2.77"
 
 [target.'cfg(windows)'.dependencies]
 bitflags = "1.3.2"
-concurrent-queue = "2.1.0"
+concurrent-queue = "2.2.0"
 pin-project-lite = "0.2.9"
 
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/src/iocp/mod.rs
+++ b/src/iocp/mod.rs
@@ -352,7 +352,8 @@ impl Poller {
         };
 
         // Only drain the queue's capacity, since this could in theory run forever.
-        core::iter::from_fn(|| self.pending_updates.pop().ok())
+        self.pending_updates
+            .try_iter()
             .take(max)
             .try_for_each(|packet| packet.update())
     }


### PR DESCRIPTION
Takes smol-rs/concurrent-queue#36 and uses it to drain events from the queue for IOCP on Windows.