### PR TITLE
Use Dependabot to update Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
     commit-message:
       prefix: ''
     labels: []
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ''
+    labels: []


### PR DESCRIPTION
Adds configuration for Dependabot to also propose updates to our Github Actions setup.