### PR TITLE
Add support for waiting on waitable handles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ version = "0.48"
 features = [
     "Win32_Foundation",
     "Win32_Networking_WinSock",
+    "Win32_Security",
     "Win32_Storage_FileSystem",
     "Win32_System_IO",
     "Win32_System_LibraryLoader",

--- a/src/iocp/afd.rs
+++ b/src/iocp/afd.rs
@@ -536,6 +536,9 @@ impl<T: fmt::Debug> fmt::Debug for IoStatusBlock<T> {
     }
 }
 
+unsafe impl<T: Send> Send for IoStatusBlock<T> {}
+unsafe impl<T: Sync> Sync for IoStatusBlock<T> {}
+
 impl<T> From<T> for IoStatusBlock<T> {
     fn from(data: T) -> Self {
         Self {

--- a/src/os/iocp.rs
+++ b/src/os/iocp.rs
@@ -87,7 +87,9 @@ pub trait PollerIocpExt: PollerSealed {
     /// let poller = Poller::new().unwrap();
     ///
     /// // Add the child process to the poller.
-    /// poller.add_waitable(&child, Event::all(0), PollMode::Oneshot).unwrap();
+    /// unsafe {
+    ///     poller.add_waitable(&child, Event::all(0), PollMode::Oneshot).unwrap();
+    /// }
     ///
     /// // Wait for the child process to exit.
     /// let mut events = vec![];
@@ -128,7 +130,9 @@ pub trait PollerIocpExt: PollerSealed {
     /// let poller = Poller::new().unwrap();
     ///
     /// // Add the child process to the poller.
-    /// poller.add_waitable(&child, Event::all(0), PollMode::Oneshot).unwrap();
+    /// unsafe {
+    ///     poller.add_waitable(&child, Event::all(0), PollMode::Oneshot).unwrap();
+    /// }
     ///
     /// // Wait for the child process to exit.
     /// let mut events = vec![];
@@ -172,7 +176,9 @@ pub trait PollerIocpExt: PollerSealed {
     /// let poller = Poller::new().unwrap();
     ///
     /// // Add the child process to the poller.
-    /// poller.add_waitable(&child, Event::all(0), PollMode::Oneshot).unwrap();
+    /// unsafe {
+    ///     poller.add_waitable(&child, Event::all(0), PollMode::Oneshot).unwrap();
+    /// }
     ///
     /// // Wait for the child process to exit.
     /// let mut events = vec![];

--- a/src/os/iocp.rs
+++ b/src/os/iocp.rs
@@ -82,14 +82,14 @@ pub trait PollerIocpExt: PollerSealed {
     /// let poller = Poller::new().unwrap();
     ///
     /// // Add the child process to the poller.
-    /// poller.add_waitable(child, Event::both(0), PollMode::Oneshot).unwrap();
+    /// poller.add_waitable(&child, Event::all(0), PollMode::Oneshot).unwrap();
     ///
     /// // Wait for the child process to exit.
     /// let mut events = vec![];
     /// poller.wait(&mut events, None).unwrap();
     ///
     /// assert_eq!(events.len(), 1);
-    /// assert_eq!(events[0], Event::both(0));
+    /// assert_eq!(events[0], Event::all(0));
     /// ```
     fn add_waitable(
         &self,
@@ -123,17 +123,17 @@ pub trait PollerIocpExt: PollerSealed {
     /// let poller = Poller::new().unwrap();
     ///
     /// // Add the child process to the poller.
-    /// poller.add_waitable(child, Event::both(0), PollMode::Oneshot).unwrap();
+    /// poller.add_waitable(&child, Event::all(0), PollMode::Oneshot).unwrap();
     ///
     /// // Wait for the child process to exit.
     /// let mut events = vec![];
     /// poller.wait(&mut events, None).unwrap();
     ///
     /// assert_eq!(events.len(), 1);
-    /// assert_eq!(events[0], Event::both(0));
+    /// assert_eq!(events[0], Event::all(0));
     ///
     /// // Modify the waitable handle.
-    /// poller.modify_waitable(child, Event::readable(0), PollMode::Oneshot).unwrap();
+    /// poller.modify_waitable(&child, Event::readable(0), PollMode::Oneshot).unwrap();
     /// ```
     fn modify_waitable(
         &self,
@@ -167,17 +167,17 @@ pub trait PollerIocpExt: PollerSealed {
     /// let poller = Poller::new().unwrap();
     ///
     /// // Add the child process to the poller.
-    /// poller.add_waitable(child, Event::both(0), PollMode::Oneshot).unwrap();
+    /// poller.add_waitable(&child, Event::all(0), PollMode::Oneshot).unwrap();
     ///
     /// // Wait for the child process to exit.
     /// let mut events = vec![];
     /// poller.wait(&mut events, None).unwrap();
     ///
     /// assert_eq!(events.len(), 1);
-    /// assert_eq!(events[0], Event::both(0));
+    /// assert_eq!(events[0], Event::all(0));
     ///
     /// // Remove the waitable handle.
-    /// poller.remove_waitable(child).unwrap();
+    /// poller.remove_waitable(&child).unwrap();
     /// ```
     fn remove_waitable(&self, handle: impl Waitable) -> io::Result<()>;
 }

--- a/src/os/iocp.rs
+++ b/src/os/iocp.rs
@@ -3,8 +3,10 @@
 pub use crate::sys::CompletionPacket;
 
 use super::__private::PollerSealed;
-use crate::Poller;
+use crate::{Event, PollMode, Poller};
+
 use std::io;
+use std::os::windows::io::AsRawHandle;
 
 /// Extension trait for the [`Poller`] type that provides functionality specific to IOCP-based
 /// platforms.
@@ -43,10 +45,169 @@ pub trait PollerIocpExt: PollerSealed {
     /// # Ok(()) }
     /// ```
     fn post(&self, packet: CompletionPacket) -> io::Result<()>;
+
+    /// Add a waitable handle to this poller.
+    ///
+    /// Some handles in Windows are "waitable", which means that they emit a "readiness" signal
+    /// after some event occurs. This function can be used to wait for such events to occur
+    /// on a handle. This function can be used in addition to regular socket polling.
+    ///
+    /// Waitable objects include the following:
+    ///
+    /// - Console inputs
+    /// - Waitable events
+    /// - Mutexes
+    /// - Processes
+    /// - Semaphores
+    /// - Threads
+    /// - Timer
+    ///
+    /// Once the object has been signalled, the poller will emit the `interest` event.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use polling::{Poller, Event, PollMode};
+    /// use polling::os::iocp::PollerIocpExt;
+    ///
+    /// use std::process::Command;
+    ///
+    /// // Spawn a new process.
+    /// let mut child = Command::new("echo")
+    ///     .arg("Hello, world!")
+    ///     .spawn()
+    ///     .unwrap();
+    ///
+    /// // Create a new poller.
+    /// let poller = Poller::new().unwrap();
+    ///
+    /// // Add the child process to the poller.
+    /// poller.add_waitable(child, Event::both(0), PollMode::Oneshot).unwrap();
+    ///
+    /// // Wait for the child process to exit.
+    /// let mut events = vec![];
+    /// poller.wait(&mut events, None).unwrap();
+    ///
+    /// assert_eq!(events.len(), 1);
+    /// assert_eq!(events[0], Event::both(0));
+    /// ```
+    fn add_waitable(
+        &self,
+        handle: impl AsRawHandle,
+        interest: Event,
+        mode: PollMode,
+    ) -> io::Result<()>;
+
+    /// Modify an existing waitable handle.
+    ///
+    /// This function can be used to change the emitted event and/or mode of an existing waitable
+    /// handle. The handle must have been previously added to the poller using [`add_waitable`].
+    ///
+    /// [`add_waitable`]: Self::add_waitable
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use polling::{Poller, Event, PollMode};
+    /// use polling::os::iocp::PollerIocpExt;
+    ///
+    /// use std::process::Command;
+    ///
+    /// // Spawn a new process.
+    /// let mut child = Command::new("echo")
+    ///     .arg("Hello, world!")
+    ///     .spawn()
+    ///     .unwrap();
+    ///
+    /// // Create a new poller.
+    /// let poller = Poller::new().unwrap();
+    ///
+    /// // Add the child process to the poller.
+    /// poller.add_waitable(child, Event::both(0), PollMode::Oneshot).unwrap();
+    ///
+    /// // Wait for the child process to exit.
+    /// let mut events = vec![];
+    /// poller.wait(&mut events, None).unwrap();
+    ///
+    /// assert_eq!(events.len(), 1);
+    /// assert_eq!(events[0], Event::both(0));
+    ///
+    /// // Modify the waitable handle.
+    /// poller.modify_waitable(child, Event::readable(0), PollMode::Oneshot).unwrap();
+    /// ```
+    fn modify_waitable(
+        &self,
+        handle: impl AsRawHandle,
+        interest: Event,
+        mode: PollMode,
+    ) -> io::Result<()>;
+
+    /// Remove a waitable handle from this poller.
+    ///
+    /// This function can be used to remove a waitable handle from the poller. The handle must
+    /// have been previously added to the poller using [`add_waitable`].
+    ///
+    /// [`add_waitable`]: Self::add_waitable
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use polling::{Poller, Event, PollMode};
+    /// use polling::os::iocp::PollerIocpExt;
+    ///
+    /// use std::process::Command;
+    ///
+    /// // Spawn a new process.
+    /// let mut child = Command::new("echo")
+    ///     .arg("Hello, world!")
+    ///     .spawn()
+    ///     .unwrap();
+    ///
+    /// // Create a new poller.
+    /// let poller = Poller::new().unwrap();
+    ///
+    /// // Add the child process to the poller.
+    /// poller.add_waitable(child, Event::both(0), PollMode::Oneshot).unwrap();
+    ///
+    /// // Wait for the child process to exit.
+    /// let mut events = vec![];
+    /// poller.wait(&mut events, None).unwrap();
+    ///
+    /// assert_eq!(events.len(), 1);
+    /// assert_eq!(events[0], Event::both(0));
+    ///
+    /// // Remove the waitable handle.
+    /// poller.remove_waitable(child).unwrap();
+    /// ```
+    fn remove_waitable(&self, handle: impl AsRawHandle) -> io::Result<()>;
 }
 
 impl PollerIocpExt for Poller {
     fn post(&self, packet: CompletionPacket) -> io::Result<()> {
         self.poller.post(packet)
+    }
+
+    fn add_waitable(
+        &self,
+        handle: impl AsRawHandle,
+        event: Event,
+        mode: PollMode,
+    ) -> io::Result<()> {
+        self.poller
+            .add_waitable(handle.as_raw_handle(), event, mode)
+    }
+
+    fn modify_waitable(
+        &self,
+        handle: impl AsRawHandle,
+        interest: Event,
+        mode: PollMode,
+    ) -> io::Result<()> {
+        self.poller
+            .modify_waitable(handle.as_raw_handle(), interest, mode)
+    }
+
+    fn remove_waitable(&self, handle: impl AsRawHandle) -> io::Result<()> {
+        self.poller.remove_waitable(handle.as_raw_handle())
     }
 }

--- a/tests/windows_waitable.rs
+++ b/tests/windows_waitable.rs
@@ -43,7 +43,7 @@ impl EventHandle {
 
     /// Reset the event object.
     fn reset(&self) -> io::Result<()> {
-        if unsafe { ResetEvent(self.0 as _) } == 0 {
+        if unsafe { ResetEvent(self.0 as _) } != 0 {
             Ok(())
         } else {
             Err(io::Error::last_os_error())
@@ -52,7 +52,7 @@ impl EventHandle {
 
     /// Set the event object.
     fn set(&self) -> io::Result<()> {
-        if unsafe { SetEvent(self.0 as _) } == 0 {
+        if unsafe { SetEvent(self.0 as _) } != 0 {
             Ok(())
         } else {
             Err(io::Error::last_os_error())

--- a/tests/windows_waitable.rs
+++ b/tests/windows_waitable.rs
@@ -1,0 +1,129 @@
+//! Tests for the waitable polling on Windows.
+
+#![cfg(windows)]
+
+use polling::os::iocp::PollerIocpExt;
+use polling::{Event, PollMode, Poller};
+
+use windows_sys::Win32::Foundation::CloseHandle;
+use windows_sys::Win32::System::Threading::{CreateEventW, ResetEvent, SetEvent};
+
+use std::io;
+use std::os::windows::io::{AsRawHandle, RawHandle};
+use std::time::Duration;
+
+/// A basic wrapper around the Windows event object.
+struct EventHandle(RawHandle);
+
+impl Drop for EventHandle {
+    fn drop(&mut self) {
+        unsafe {
+            CloseHandle(self.0 as _);
+        }
+    }
+}
+
+impl EventHandle {
+    fn new(manual_reset: bool) -> io::Result<Self> {
+        let handle = unsafe {
+            CreateEventW(
+                std::ptr::null_mut(),
+                manual_reset as _,
+                false as _,
+                std::ptr::null(),
+            )
+        };
+
+        if handle == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(Self(handle as _))
+        }
+    }
+
+    /// Reset the event object.
+    fn reset(&self) -> io::Result<()> {
+        if unsafe { ResetEvent(self.0 as _) } == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    /// Set the event object.
+    fn set(&self) -> io::Result<()> {
+        if unsafe { SetEvent(self.0 as _) } == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+}
+
+impl AsRawHandle for EventHandle {
+    fn as_raw_handle(&self) -> RawHandle {
+        self.0
+    }
+}
+
+#[test]
+fn smoke() {
+    let poller = Poller::new().unwrap();
+
+    let event = EventHandle::new(true).unwrap();
+
+    poller
+        .add_waitable(&event, Event::all(0), PollMode::Oneshot)
+        .unwrap();
+
+    let mut events = vec![];
+    poller
+        .wait(&mut events, Some(Duration::from_millis(100)))
+        .unwrap();
+
+    assert!(events.is_empty());
+
+    // Signal the event.
+    event.set().unwrap();
+
+    poller
+        .wait(&mut events, Some(Duration::from_millis(100)))
+        .unwrap();
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0], Event::all(0));
+
+    // Interest should be cleared.
+    events.clear();
+    poller
+        .wait(&mut events, Some(Duration::from_millis(100)))
+        .unwrap();
+
+    assert!(events.is_empty());
+
+    // If we modify the waitable, it should be added again.
+    poller
+        .modify_waitable(&event, Event::all(0), PollMode::Oneshot)
+        .unwrap();
+
+    events.clear();
+    poller
+        .wait(&mut events, Some(Duration::from_millis(100)))
+        .unwrap();
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0], Event::all(0));
+
+    // If we reset the event, it should not be signaled.
+    event.reset().unwrap();
+    poller
+        .modify_waitable(&event, Event::all(0), PollMode::Oneshot)
+        .unwrap();
+
+    events.clear();
+    poller
+        .wait(&mut events, Some(Duration::from_millis(100)))
+        .unwrap();
+
+    assert!(events.is_empty());
+}


### PR DESCRIPTION
This PR adds support to `Poller` on Windows for waiting on waitable handles,  like processes and threads. For now, this just uses the thread pool, but in the future we could use wait-completion packets instead. Closes #98

~~Needs more testing.~~ Looks good from my end.