### PR TITLE
Rework the API for I/O safety

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,11 +28,6 @@ freebsd_task:
     - sudo sysctl net.inet.tcp.blackhole=0
     - . $HOME/.cargo/env
     - cargo test --target $TARGET
-    # Test async-io
-    - git clone https://github.com/smol-rs/async-io.git
-    - echo '[patch.crates-io]' >> async-io/Cargo.toml
-    - echo 'polling = { path = ".." }' >> async-io/Cargo.toml
-    - cargo test --target $TARGET --manifest-path=async-io/Cargo.toml
 
 netbsd_task:
   name: test ($TARGET)
@@ -49,11 +44,6 @@ netbsd_task:
   test_script:
     - . $HOME/.cargo/env
     - cargo test
-    # Test async-io
-    - git clone https://github.com/smol-rs/async-io.git
-    - echo '[patch.crates-io]' >> async-io/Cargo.toml
-    - echo 'polling = { path = ".." }' >> async-io/Cargo.toml
-    - cargo test --manifest-path=async-io/Cargo.toml
 
 openbsd_task:
   name: test ($TARGET)
@@ -69,8 +59,3 @@ openbsd_task:
     - pkg_add git rust
   test_script:
     - cargo test
-    # Test async-io
-    - git clone https://github.com/smol-rs/async-io.git
-    - echo '[patch.crates-io]' >> async-io/Cargo.toml
-    - echo 'polling = { path = ".." }' >> async-io/Cargo.toml
-    - cargo test --manifest-path=async-io/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,14 +56,6 @@ jobs:
           RUSTFLAGS: ${{ env.RUSTFLAGS }} --cfg polling_test_poll_backend
         if: startsWith(matrix.os, 'ubuntu')
       - run: cargo hack build --feature-powerset --no-dev-deps
-      - name: Clone async-io
-        run: git clone https://github.com/smol-rs/async-io.git
-      - name: Add patch section
-        run: echo '[patch.crates-io]' >> async-io/Cargo.toml
-      - name: Patch polling
-        run: echo 'polling = { path = ".." }' >> async-io/Cargo.toml
-      - name: Test async-io
-        run: cargo test --manifest-path=async-io/Cargo.toml
 
   cross:
     runs-on: ${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tracing = { version = "0.1.37", default-features = false }
 
 [target.'cfg(any(unix, target_os = "fuchsia", target_os = "vxworks"))'.dependencies]
 libc = "0.2.77"
-rustix = { version = "0.37.11", features = ["process", "time", "fs", "std"], default-features = false }
+rustix = { version = "0.38", features = ["event", "fs", "pipe", "process", "std", "time"], default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 bitflags = "2"

--- a/examples/two-listeners.rs
+++ b/examples/two-listeners.rs
@@ -10,8 +10,10 @@ fn main() -> io::Result<()> {
     l2.set_nonblocking(true)?;
 
     let poller = Poller::new()?;
-    poller.add(&l1, Event::readable(1))?;
-    poller.add(&l2, Event::readable(2))?;
+    unsafe {
+        poller.add(&l1, Event::readable(1))?;
+        poller.add(&l2, Event::readable(2))?;
+    }
 
     println!("You can connect to the server using `nc`:");
     println!(" $ nc 127.0.0.1 8001");

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -1,11 +1,11 @@
 //! Bindings to kqueue (macOS, iOS, tvOS, watchOS, FreeBSD, NetBSD, OpenBSD, DragonFly BSD).
 
 use std::io;
-use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
+use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
 use std::time::Duration;
 
-use rustix::fd::OwnedFd;
-use rustix::io::{fcntl_setfd, kqueue, Errno, FdFlags};
+use rustix::event::kqueue;
+use rustix::io::{fcntl_setfd, Errno, FdFlags};
 
 use crate::{Event, PollMode};
 
@@ -272,7 +272,7 @@ pub(crate) fn mode_to_flags(mode: PollMode) -> kqueue::EventFlags {
 ))]
 mod notify {
     use super::Poller;
-    use rustix::io::kqueue;
+    use rustix::event::kqueue;
     use std::io;
     use std::os::unix::io::BorrowedFd;
 
@@ -429,7 +429,7 @@ mod notify {
 
         /// Whether this raw file descriptor is associated with this pipe.
         pub(super) fn has_fd(&self, fd: BorrowedFd<'_>) -> bool {
-            self.read_stream.as_raw_fd() == fd
+            self.read_stream.as_raw_fd() == fd.as_raw_fd()
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,9 @@
 //!
 //! // Create a poller and register interest in readability on the socket.
 //! let poller = Poller::new()?;
-//! poller.add(&socket, Event::readable(key))?;
+//! unsafe {
+//!     poller.add(&socket, Event::readable(key))?;
+//! }
 //!
 //! // The event loop.
 //! let mut events = Vec::new();
@@ -46,6 +48,8 @@
 //!         }
 //!     }
 //! }
+//!
+//! poller.delete(&socket)?;
 //! # std::io::Result::Ok(())
 //! ```
 
@@ -267,8 +271,11 @@ impl Poller {
     /// [`modify()`][`Poller::modify()`] again after an event is delivered if we're interested in
     /// the next event of the same kind.
     ///
-    /// Don't forget to [`delete()`][`Poller::delete()`] the file descriptor or socket when it is
-    /// no longer used!
+    /// # Safety
+    ///
+    /// The source must be [`delete()`]d from this `Poller` before it is dropped.
+    ///
+    /// [`delete()`]: Poller::delete
     ///
     /// # Errors
     ///
@@ -289,10 +296,14 @@ impl Poller {
     /// let key = 7;
     ///
     /// let poller = Poller::new()?;
-    /// poller.add(&source, Event::all(key))?;
+    /// unsafe {
+    ///     poller.add(&source, Event::all(key))?;
+    /// }
+    /// poller.delete(&source)?;
     /// # std::io::Result::Ok(())
     /// ```
-    pub fn add(&self, source: impl Source, interest: Event) -> io::Result<()> {
+    #[allow(unsafe_op_in_unsafe_fn)]
+    pub unsafe fn add(&self, source: impl AsRawSource, interest: Event) -> io::Result<()> {
         self.add_with_mode(source, interest, PollMode::Oneshot)
     }
 
@@ -301,13 +312,19 @@ impl Poller {
     /// This is identical to the `add()` function, but allows specifying the
     /// polling mode to use for this socket.
     ///
+    /// # Safety
+    ///
+    /// The source must be [`delete()`]d from this `Poller` before it is dropped.
+    ///
+    /// [`delete()`]: Poller::delete
+    ///
     /// # Errors
     ///
     /// If the operating system does not support the specified mode, this function
     /// will return an error.
-    pub fn add_with_mode(
+    pub unsafe fn add_with_mode(
         &self,
-        source: impl Source,
+        source: impl AsRawSource,
         interest: Event,
         mode: PollMode,
     ) -> io::Result<()> {
@@ -348,7 +365,7 @@ impl Poller {
     /// # let source = std::net::TcpListener::bind("127.0.0.1:0")?;
     /// # let key = 7;
     /// # let poller = Poller::new()?;
-    /// # poller.add(&source, Event::none(key))?;
+    /// # unsafe { poller.add(&source, Event::none(key))?; }
     /// poller.modify(&source, Event::all(key))?;
     /// # std::io::Result::Ok(())
     /// ```
@@ -360,8 +377,9 @@ impl Poller {
     /// # let source = std::net::TcpListener::bind("127.0.0.1:0")?;
     /// # let key = 7;
     /// # let poller = Poller::new()?;
-    /// # poller.add(&source, Event::none(key))?;
+    /// # unsafe { poller.add(&source, Event::none(key))?; }
     /// poller.modify(&source, Event::readable(key))?;
+    /// # poller.delete(&source)?;
     /// # std::io::Result::Ok(())
     /// ```
     ///
@@ -372,8 +390,9 @@ impl Poller {
     /// # let poller = Poller::new()?;
     /// # let key = 7;
     /// # let source = std::net::TcpListener::bind("127.0.0.1:0")?;
-    /// # poller.add(&source, Event::none(key))?;
+    /// # unsafe { poller.add(&source, Event::none(key))? };
     /// poller.modify(&source, Event::writable(key))?;
+    /// # poller.delete(&source)?;
     /// # std::io::Result::Ok(())
     /// ```
     ///
@@ -384,11 +403,12 @@ impl Poller {
     /// # let source = std::net::TcpListener::bind("127.0.0.1:0")?;
     /// # let key = 7;
     /// # let poller = Poller::new()?;
-    /// # poller.add(&source, Event::none(key))?;
+    /// # unsafe { poller.add(&source, Event::none(key))?; }
     /// poller.modify(&source, Event::none(key))?;
+    /// # poller.delete(&source)?;
     /// # std::io::Result::Ok(())
     /// ```
-    pub fn modify(&self, source: impl Source, interest: Event) -> io::Result<()> {
+    pub fn modify(&self, source: impl AsSource, interest: Event) -> io::Result<()> {
         self.modify_with_mode(source, interest, PollMode::Oneshot)
     }
 
@@ -409,7 +429,7 @@ impl Poller {
     /// an error.
     pub fn modify_with_mode(
         &self,
-        source: impl Source,
+        source: impl AsSource,
         interest: Event,
         mode: PollMode,
     ) -> io::Result<()> {
@@ -419,7 +439,7 @@ impl Poller {
                 "the key is not allowed to be `usize::MAX`",
             ));
         }
-        self.poller.modify(source.raw(), interest, mode)
+        self.poller.modify(source.source(), interest, mode)
     }
 
     /// Removes a file descriptor or socket from the poller.
@@ -438,12 +458,12 @@ impl Poller {
     /// let key = 7;
     ///
     /// let poller = Poller::new()?;
-    /// poller.add(&socket, Event::all(key))?;
+    /// unsafe { poller.add(&socket, Event::all(key))?; }
     /// poller.delete(&socket)?;
     /// # std::io::Result::Ok(())
     /// ```
-    pub fn delete(&self, source: impl Source) -> io::Result<()> {
-        self.poller.delete(source.raw())
+    pub fn delete(&self, source: impl AsSource) -> io::Result<()> {
+        self.poller.delete(source.source())
     }
 
     /// Waits for at least one I/O event and returns the number of new events.
@@ -476,10 +496,13 @@ impl Poller {
     /// let key = 7;
     ///
     /// let poller = Poller::new()?;
-    /// poller.add(&socket, Event::all(key))?;
+    /// unsafe {
+    ///     poller.add(&socket, Event::all(key))?;
+    /// }
     ///
     /// let mut events = Vec::new();
     /// let n = poller.wait(&mut events, Some(Duration::from_secs(1)))?;
+    /// poller.delete(&socket)?;
     /// # std::io::Result::Ok(())
     /// ```
     pub fn wait(&self, events: &mut Vec<Event>, timeout: Option<Duration>) -> io::Result<usize> {
@@ -618,45 +641,65 @@ impl fmt::Debug for Poller {
 
 cfg_if! {
     if #[cfg(unix)] {
-        use std::os::unix::io::{AsRawFd, RawFd};
+        use std::os::unix::io::{AsRawFd, RawFd, AsFd, BorrowedFd};
 
-        /// A [`RawFd`] or a reference to a type implementing [`AsRawFd`].
-        pub trait Source {
-            /// Returns the [`RawFd`] for this I/O object.
+        /// A resource with a raw file descriptor.
+        pub trait AsRawSource {
+            /// Returns the raw file descriptor.
             fn raw(&self) -> RawFd;
         }
 
-        impl Source for RawFd {
-            fn raw(&self) -> RawFd {
-                *self
-            }
-        }
-
-        impl<T: AsRawFd> Source for &T {
+        impl<T: AsRawFd> AsRawSource for &T {
             fn raw(&self) -> RawFd {
                 self.as_raw_fd()
             }
         }
-    } else if #[cfg(windows)] {
-        use std::os::windows::io::{AsRawSocket, RawSocket};
 
-        /// A [`RawSocket`] or a reference to a type implementing [`AsRawSocket`].
-        pub trait Source {
-            /// Returns the [`RawSocket`] for this I/O object.
+        impl AsRawSource for RawFd {
+            fn raw(&self) -> RawFd {
+                *self
+            }
+        }
+
+        /// A resource with a borrowed file descriptor.
+        pub trait AsSource: AsFd {
+            /// Returns the borrowed file descriptor.
+            fn source(&self) -> BorrowedFd<'_> {
+                self.as_fd()
+            }
+        }
+
+        impl<T: AsFd> AsSource for T {}
+    } else if #[cfg(windows)] {
+        use std::os::windows::io::{AsRawSocket, RawSocket, AsSocket, BorrowedSocket};
+
+        /// A resource with a raw socket.
+        pub trait AsRawSource {
+            /// Returns the raw socket.
             fn raw(&self) -> RawSocket;
         }
 
-        impl Source for RawSocket {
+        impl<T: AsRawSocket> AsRawSource for &T {
+            fn raw(&self) -> RawSocket {
+                self.as_raw_socket()
+            }
+        }
+
+        impl AsRawSource for RawSocket {
             fn raw(&self) -> RawSocket {
                 *self
             }
         }
 
-        impl<T: AsRawSocket> Source for &T {
-            fn raw(&self) -> RawSocket {
-                self.as_raw_socket()
+        /// A resource with a borrowed socket.
+        pub trait AsSource: AsSocket {
+            /// Returns the borrowed socket.
+            fn source(&self) -> BorrowedSocket<'_> {
+                self.as_socket()
             }
         }
+
+        impl<T: AsSocket> AsSource for T {}
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 #![cfg(feature = "std")]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
-#![allow(clippy::useless_conversion, clippy::unnecessary_cast)]
+#![allow(clippy::useless_conversion, clippy::unnecessary_cast, unused_unsafe)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 use std::fmt;
@@ -302,7 +302,6 @@ impl Poller {
     /// poller.delete(&source)?;
     /// # std::io::Result::Ok(())
     /// ```
-    #[allow(unsafe_op_in_unsafe_fn)]
     pub unsafe fn add(&self, source: impl AsRawSource, interest: Event) -> io::Result<()> {
         self.add_with_mode(source, interest, PollMode::Oneshot)
     }

--- a/src/os/kqueue.rs
+++ b/src/os/kqueue.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::process::Child;
 use std::time::Duration;
 
-use rustix::io::kqueue;
+use rustix::event::kqueue;
 
 use super::__private::PollerSealed;
 use __private::FilterSealed;
@@ -238,7 +238,7 @@ unsafe impl FilterSealed for Timer {
 impl Filter for Timer {}
 
 mod __private {
-    use rustix::io::kqueue;
+    use rustix::event::kqueue;
 
     #[doc(hidden)]
     pub unsafe trait FilterSealed {

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -7,12 +7,11 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Condvar, Mutex};
 use std::time::{Duration, Instant};
 
+use rustix::event::{poll, PollFd, PollFlags};
 use rustix::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
 use rustix::fs::{fcntl_getfl, fcntl_setfl, OFlags};
-use rustix::io::{
-    fcntl_getfd, fcntl_setfd, pipe, pipe_with, poll, read, write, FdFlags, PipeFlags, PollFd,
-    PollFlags,
-};
+use rustix::io::{fcntl_getfd, fcntl_setfd, read, write, FdFlags};
+use rustix::pipe::{pipe, pipe_with, PipeFlags};
 
 // std::os::unix doesn't exist on Fuchsia
 type RawFd = std::os::raw::c_int;

--- a/src/port.rs
+++ b/src/port.rs
@@ -4,8 +4,9 @@ use std::io;
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::time::Duration;
 
+use rustix::event::{port, PollFlags};
 use rustix::fd::OwnedFd;
-use rustix::io::{fcntl_getfd, fcntl_setfd, port, FdFlags, PollFlags};
+use rustix::io::{fcntl_getfd, fcntl_setfd, FdFlags};
 
 use crate::{Event, PollMode};
 

--- a/src/port.rs
+++ b/src/port.rs
@@ -42,13 +42,17 @@ impl Poller {
     }
 
     /// Adds a file descriptor.
-    pub fn add(&self, fd: RawFd, ev: Event, mode: PollMode) -> io::Result<()> {
+    ///
+    /// # Safety
+    ///
+    /// The `fd` must be a valid file descriptor and it must last until it is deleted.
+    pub unsafe fn add(&self, fd: RawFd, ev: Event, mode: PollMode) -> io::Result<()> {
         // File descriptors don't need to be added explicitly, so just modify the interest.
-        self.modify(fd, ev, mode)
+        self.modify(BorrowedFd::borrow_raw(fd), ev, mode)
     }
 
     /// Modifies an existing file descriptor.
-    pub fn modify(&self, fd: RawFd, ev: Event, mode: PollMode) -> io::Result<()> {
+    pub fn modify(&self, fd: BorrowedFd<'_>, ev: Event, mode: PollMode) -> io::Result<()> {
         let span = tracing::trace_span!(
             "modify",
             port_fd = ?self.port_fd.as_raw_fd(),
@@ -79,7 +83,7 @@ impl Poller {
     }
 
     /// Deletes a file descriptor.
-    pub fn delete(&self, fd: RawFd) -> io::Result<()> {
+    pub fn delete(&self, fd: BorrowedFd<'_>) -> io::Result<()> {
         let span = tracing::trace_span!(
             "delete",
             port_fd = ?self.port_fd.as_raw_fd(),

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -7,7 +7,9 @@ use std::time::Duration;
 fn basic_io() {
     let poller = Poller::new().unwrap();
     let (read, mut write) = tcp_pair().unwrap();
-    poller.add(&read, Event::readable(1)).unwrap();
+    unsafe {
+        poller.add(&read, Event::readable(1)).unwrap();
+    }
 
     // Nothing should be available at first.
     let mut events = vec![];
@@ -28,6 +30,8 @@ fn basic_io() {
         1
     );
     assert_eq!(&*events, &[Event::readable(1)]);
+
+    poller.delete(&read).unwrap();
 }
 
 fn tcp_pair() -> io::Result<(TcpStream, TcpStream)> {

--- a/tests/many_connections.rs
+++ b/tests/many_connections.rs
@@ -20,7 +20,9 @@ fn many_connections() {
     let poller = polling::Poller::new().unwrap();
 
     for (i, reader, _) in connections.iter() {
-        poller.add(reader, polling::Event::readable(*i)).unwrap();
+        unsafe {
+            poller.add(reader, polling::Event::readable(*i)).unwrap();
+        }
     }
 
     let mut events = vec![];

--- a/tests/other_modes.rs
+++ b/tests/other_modes.rs
@@ -16,8 +16,7 @@ fn level_triggered() {
 
     // Create our poller and register our streams.
     let poller = Poller::new().unwrap();
-    if poller
-        .add_with_mode(&reader, Event::readable(reader_token), PollMode::Level)
+    if unsafe { poller.add_with_mode(&reader, Event::readable(reader_token), PollMode::Level) }
         .is_err()
     {
         // Only panic if we're on a platform that should support level mode.
@@ -92,8 +91,7 @@ fn edge_triggered() {
 
     // Create our poller and register our streams.
     let poller = Poller::new().unwrap();
-    if poller
-        .add_with_mode(&reader, Event::readable(reader_token), PollMode::Edge)
+    if unsafe { poller.add_with_mode(&reader, Event::readable(reader_token), PollMode::Edge) }
         .is_err()
     {
         // Only panic if we're on a platform that should support level mode.
@@ -170,13 +168,14 @@ fn edge_oneshot_triggered() {
 
     // Create our poller and register our streams.
     let poller = Poller::new().unwrap();
-    if poller
-        .add_with_mode(
+    if unsafe {
+        poller.add_with_mode(
             &reader,
             Event::readable(reader_token),
             PollMode::EdgeOneshot,
         )
-        .is_err()
+    }
+    .is_err()
     {
         // Only panic if we're on a platform that should support level mode.
         cfg_if::cfg_if! {


### PR DESCRIPTION
This reworks the `polling` API with I/O safety in mind. See #38 and smol-rs/smol#244 for more information.

This is a breaking change that makes the `add()` family of functions `unsafe`. I am very open to alternatives to this change.

The indirect effects of this change is that is makes `async_io::Async::get_mut` and `read/write_with_mut` unsafe, as well as having implications for the `AsyncRead/AsyncWrite` impls as well. See smol-rs/async-io#142. I would appreciate community feedback on these changes.