### PR TITLE
Remove the bitflags dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ libc = "0.2.77"
 rustix = { version = "0.37.11", features = ["process", "time", "fs", "std"], default-features = false }
 
 [target.'cfg(windows)'.dependencies]
-bitflags = "2"
 concurrent-queue = "2.2.0"
 pin-project-lite = "0.2.9"
 

--- a/src/iocp/afd.rs
+++ b/src/iocp/afd.rs
@@ -7,6 +7,7 @@ use std::fmt;
 use std::io;
 use std::marker::{PhantomData, PhantomPinned};
 use std::mem::{self, size_of, transmute, MaybeUninit};
+use std::ops;
 use std::os::windows::prelude::{AsRawHandle, RawHandle, RawSocket};
 use std::pin::Pin;
 use std::ptr;
@@ -65,18 +66,42 @@ impl AfdPollInfo {
     }
 }
 
-bitflags::bitflags! {
-    #[derive(Default, Copy, Clone)]
-    #[repr(transparent)]
-    pub(super) struct AfdPollMask: u32 {
-        const RECEIVE = 0x001;
-        const RECEIVE_EXPEDITED = 0x002;
-        const SEND = 0x004;
-        const DISCONNECT = 0x008;
-        const ABORT = 0x010;
-        const LOCAL_CLOSE = 0x020;
-        const ACCEPT = 0x080;
-        const CONNECT_FAIL = 0x100;
+#[derive(Default, Copy, Clone)]
+#[repr(transparent)]
+pub(super) struct AfdPollMask(u32);
+
+impl AfdPollMask {
+    pub(crate) const RECEIVE: AfdPollMask = AfdPollMask(0x001);
+    pub(crate) const RECEIVE_EXPEDITED: AfdPollMask = AfdPollMask(0x002);
+    pub(crate) const SEND: AfdPollMask = AfdPollMask(0x004);
+    pub(crate) const DISCONNECT: AfdPollMask = AfdPollMask(0x008);
+    pub(crate) const ABORT: AfdPollMask = AfdPollMask(0x010);
+    pub(crate) const LOCAL_CLOSE: AfdPollMask = AfdPollMask(0x020);
+    pub(crate) const ACCEPT: AfdPollMask = AfdPollMask(0x080);
+    pub(crate) const CONNECT_FAIL: AfdPollMask = AfdPollMask(0x100);
+
+    /// Creates an empty mask.
+    pub(crate) fn empty() -> AfdPollMask {
+        AfdPollMask(0)
+    }
+
+    /// Checks if this mask contains the other mask.
+    pub(crate) fn intersects(self, other: AfdPollMask) -> bool {
+        (self.0 & other.0) != 0
+    }
+}
+
+impl ops::BitOr for AfdPollMask {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self {
+        AfdPollMask(self.0 | rhs.0)
+    }
+}
+
+impl ops::BitOrAssign for AfdPollMask {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
     }
 }
 

--- a/src/iocp/mod.rs
+++ b/src/iocp/mod.rs
@@ -679,7 +679,7 @@ impl PacketUnwrapped {
                         let events = afd_data.events();
 
                         // If we closed the socket, remove it from being polled.
-                        if events.contains(AfdPollMask::LOCAL_CLOSE) {
+                        if events.intersects(AfdPollMask::LOCAL_CLOSE) {
                             let source = lock!(poller.sources.write())
                                 .remove(&socket_state.socket)
                                 .unwrap();


### PR DESCRIPTION
The `bitflags` crate is planning on doing a breaking change, see bitflags/bitflags#369. This is a little bit too much version churn for my liking, and it's not like we expose it publicly. This PR removes it from the Windows backend.