### PR TITLE
Partial support for Rustix 0.38.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tracing = { version = "0.1.37", default-features = false }
 
 [target.'cfg(any(unix, target_os = "fuchsia", target_os = "vxworks"))'.dependencies]
 libc = "0.2.77"
-rustix = { version = "0.37.11", features = ["process", "time", "fs", "std"], default-features = false }
+rustix = { version = "0.38.6", features = ["process", "time", "fs", "std", "event"], default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 concurrent-queue = "2.2.0"

--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -5,8 +5,9 @@ use std::io;
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::time::Duration;
 
+use rustix::event::{epoll, eventfd, EventfdFlags};
 use rustix::fd::OwnedFd;
-use rustix::io::{epoll, eventfd, read, write, EventfdFlags};
+use rustix::io::{read, write};
 use rustix::time::{
     timerfd_create, timerfd_settime, Itimerspec, TimerfdClockId, TimerfdFlags, TimerfdTimerFlags,
     Timespec,
@@ -31,7 +32,7 @@ impl Poller {
         // Create an epoll instance.
         //
         // Use `epoll_create1` with `EPOLL_CLOEXEC`.
-        let epoll_fd = epoll::epoll_create(epoll::CreateFlags::CLOEXEC)?;
+        let epoll_fd = epoll::create(epoll::CreateFlags::CLOEXEC)?;
 
         // Set up eventfd and timerfd.
         let event_fd = eventfd(0, EventfdFlags::CLOEXEC | EventfdFlags::NONBLOCK)?;
@@ -94,10 +95,10 @@ impl Poller {
         );
         let _enter = span.enter();
 
-        epoll::epoll_add(
+        epoll::add(
             &self.epoll_fd,
             unsafe { rustix::fd::BorrowedFd::borrow_raw(fd) },
-            ev.key as u64,
+            epoll::EventData::new_u64(ev.key as u64),
             epoll_flags(&ev, mode),
         )?;
 
@@ -114,10 +115,10 @@ impl Poller {
         );
         let _enter = span.enter();
 
-        epoll::epoll_mod(
+        epoll::modify(
             &self.epoll_fd,
             unsafe { rustix::fd::BorrowedFd::borrow_raw(fd) },
-            ev.key as u64,
+            epoll::EventData::new_u64(ev.key as u64),
             epoll_flags(&ev, mode),
         )?;
 
@@ -133,7 +134,7 @@ impl Poller {
         );
         let _enter = span.enter();
 
-        epoll::epoll_del(&self.epoll_fd, unsafe {
+        epoll::delete(&self.epoll_fd, unsafe {
             rustix::fd::BorrowedFd::borrow_raw(fd)
         })?;
 
@@ -195,7 +196,7 @@ impl Poller {
         };
 
         // Wait for I/O events.
-        epoll::epoll_wait(&self.epoll_fd, &mut events.list, timeout_ms)?;
+        epoll::wait(&self.epoll_fd, &mut events.list, timeout_ms)?;
         tracing::trace!(
             epoll_fd = ?self.epoll_fd.as_raw_fd(),
             res = ?events.list.len(),
@@ -310,10 +311,6 @@ impl Events {
 
     /// Iterates over I/O events.
     pub fn iter(&self) -> impl Iterator<Item = Event> + '_ {
-        self.list.iter().map(|(flags, data)| Event {
-            key: data as usize,
-            readable: flags.intersects(read_flags()),
-            writable: flags.intersects(write_flags()),
-        })
+        self.list.iter()
     }
 }

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -4,8 +4,9 @@ use std::io;
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::time::Duration;
 
+use rustix::event::kqueue;
 use rustix::fd::OwnedFd;
-use rustix::io::{fcntl_setfd, kqueue, Errno, FdFlags};
+use rustix::io::{fcntl_setfd, Errno, FdFlags};
 
 use crate::{Event, PollMode};
 
@@ -268,7 +269,7 @@ pub(crate) fn mode_to_flags(mode: PollMode) -> kqueue::EventFlags {
 ))]
 mod notify {
     use super::Poller;
-    use rustix::io::kqueue;
+    use rustix::event::kqueue;
     use std::io;
     use std::os::unix::io::RawFd;
 

--- a/src/os/kqueue.rs
+++ b/src/os/kqueue.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::process::Child;
 use std::time::Duration;
 
-use rustix::io::kqueue;
+use rustix::event::kqueue;
 
 use super::__private::PollerSealed;
 use __private::FilterSealed;
@@ -238,7 +238,7 @@ unsafe impl FilterSealed for Timer {
 impl Filter for Timer {}
 
 mod __private {
-    use rustix::io::kqueue;
+    use rustix::event::kqueue;
 
     #[doc(hidden)]
     pub unsafe trait FilterSealed {


### PR DESCRIPTION
Rustix 0.38.x has made breaking changes to the event APIs by splitting some of the modules. See https://github.com/bytecodealliance/rustix/commit/29b07bbdac1c7d704c836db337c13928b47bcdf3

This PR updates the implementations for `kqueue` and `epoll` to use the new module structure. I tried to update `poll` as well, but the various `pipe`, `pipe_with` and similar functions now seem to be private (in the backend only) and that's beyond my basic understanding of how this works, unfortunately.