### PR TITLE
Remove patch.crates-io now that rustix 0.38.7 is out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         run: rustup component add rust-src
       - name: Check selected Tier 3 targets
         if: matrix.rust == 'nightly' && matrix.os == 'ubuntu-latest'
-        run: cargo +nightly check -Z build-std --target=riscv32imc-esp-espidf --config 'patch.crates-io.rustix.git="https://github.com/bytecodealliance/rustix"'
+        run: cargo +nightly check -Z build-std --target=riscv32imc-esp-espidf
 
   cross:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Subject says it all - rustix.0.38.7 [just got released](https://github.com/bytecodealliance/rustix/pull/770).