### PR TITLE
Allow pinning Rust nightly to concrete version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,11 +57,11 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
       - run: cargo hack build --feature-powerset --no-dev-deps
       - name: Add rust-src
-        if: matrix.rust == 'nightly'
+        if: startsWith(matrix.rust, 'nightly')
         run: rustup component add rust-src
       - name: Check selected Tier 3 targets
-        if: matrix.rust == 'nightly' && matrix.os == 'ubuntu-latest'
-        run: cargo +nightly check -Z build-std --target=riscv32imc-esp-espidf
+        if: startsWith(matrix.rust, 'nightly') && matrix.os == 'ubuntu-latest'
+        run: cargo check -Z build-std --target=riscv32imc-esp-espidf
 
   cross:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
A nit really: replace `==` with `startWith` so that if one day we decide to pin `nightly` to a specific version (i.e. `nightly-2023-08-01` the Tier 3 CI would still run.