### PR TITLE
Extract the Events struct and make the Event struct opaque

### DIFF
--- a/examples/two-listeners.rs
+++ b/examples/two-listeners.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::net::TcpListener;
 
-use polling::{Event, Poller};
+use polling::{Event, Events, Poller};
 
 fn main() -> io::Result<()> {
     let l1 = TcpListener::bind("127.0.0.1:8001")?;
@@ -19,12 +19,12 @@ fn main() -> io::Result<()> {
     println!(" $ nc 127.0.0.1 8001");
     println!(" $ nc 127.0.0.1 8002");
 
-    let mut events = Vec::new();
+    let mut events = Events::new();
     loop {
         events.clear();
         poller.wait(&mut events, None)?;
 
-        for ev in &events {
+        for ev in events.iter() {
             match ev.key {
                 1 => {
                     println!("Accept on l1");

--- a/examples/wait-signal.rs
+++ b/examples/wait-signal.rs
@@ -13,7 +13,7 @@
 ))]
 mod example {
     use polling::os::kqueue::{PollerKqueueExt, Signal};
-    use polling::{PollMode, Poller};
+    use polling::{Events, PollMode, Poller};
 
     pub(super) fn main2() {
         // Create a poller.
@@ -23,7 +23,7 @@ mod example {
         let sigint = Signal(libc::SIGINT);
         poller.add_filter(sigint, 1, PollMode::Oneshot).unwrap();
 
-        let mut events = vec![];
+        let mut events = Events::new();
 
         println!("Press Ctrl+C to exit...");
 
@@ -32,7 +32,7 @@ mod example {
             poller.wait(&mut events, None).unwrap();
 
             // Process events.
-            for ev in events.drain(..) {
+            for ev in events.iter() {
                 match ev.key {
                     1 => {
                         println!("SIGINT received");
@@ -41,6 +41,8 @@ mod example {
                     _ => unreachable!(),
                 }
             }
+
+            events.clear();
         }
     }
 }

--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -59,11 +59,7 @@ impl Poller {
 
             poller.add(
                 poller.event_fd.as_raw_fd(),
-                Event {
-                    key: crate::NOTIFY_KEY,
-                    readable: true,
-                    writable: false,
-                },
+                Event::readable(crate::NOTIFY_KEY),
                 PollMode::Oneshot,
             )?;
         }
@@ -177,11 +173,7 @@ impl Poller {
             // Set interest in timerfd.
             self.modify(
                 timer_fd.as_fd(),
-                Event {
-                    key: crate::NOTIFY_KEY,
-                    readable: true,
-                    writable: false,
-                },
+                Event::readable(crate::NOTIFY_KEY),
                 PollMode::Oneshot,
             )?;
         }
@@ -213,11 +205,7 @@ impl Poller {
         let _ = read(&self.event_fd, &mut buf);
         self.modify(
             self.event_fd.as_fd(),
-            Event {
-                key: crate::NOTIFY_KEY,
-                readable: true,
-                writable: false,
-            },
+            Event::readable(crate::NOTIFY_KEY),
             PollMode::Oneshot,
         )?;
         Ok(())
@@ -322,6 +310,7 @@ impl Events {
                 key: ev.data.u64() as usize,
                 readable: flags.intersects(read_flags()),
                 writable: flags.intersects(write_flags()),
+                extra: EventExtra { flags },
             }
         })
     }
@@ -334,5 +323,20 @@ impl Events {
     /// Get the capacity of the list.
     pub fn capacity(&self) -> usize {
         self.list.capacity()
+    }
+}
+
+/// Extra information about this event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EventExtra {
+    flags: epoll::EventFlags,
+}
+
+impl EventExtra {
+    /// Create an empty version of the data.
+    pub fn empty() -> EventExtra {
+        EventExtra {
+            flags: epoll::EventFlags::empty(),
+        }
     }
 }

--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -308,9 +308,9 @@ unsafe impl Send for Events {}
 
 impl Events {
     /// Creates an empty list.
-    pub fn new() -> Events {
+    pub fn with_capacity(cap: usize) -> Events {
         Events {
-            list: epoll::EventVec::with_capacity(1024),
+            list: epoll::EventVec::with_capacity(cap),
         }
     }
 
@@ -324,5 +324,15 @@ impl Events {
                 writable: flags.intersects(write_flags()),
             }
         })
+    }
+
+    /// Clear the list.
+    pub fn clear(&mut self) {
+        self.list.clear();
+    }
+
+    /// Get the capacity of the list.
+    pub fn capacity(&self) -> usize {
+        self.list.capacity()
     }
 }

--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -102,7 +102,7 @@ impl Poller {
             &self.epoll_fd,
             unsafe { rustix::fd::BorrowedFd::borrow_raw(fd) },
             epoll::EventData::new_u64(ev.key as u64),
-            epoll_flags(&ev, mode),
+            epoll_flags(&ev, mode) | ev.extra.flags,
         )?;
 
         Ok(())
@@ -122,7 +122,7 @@ impl Poller {
             &self.epoll_fd,
             fd,
             epoll::EventData::new_u64(ev.key as u64),
-            epoll_flags(&ev, mode),
+            epoll_flags(&ev, mode) | ev.extra.flags,
         )?;
 
         Ok(())
@@ -338,5 +338,25 @@ impl EventExtra {
         EventExtra {
             flags: epoll::EventFlags::empty(),
         }
+    }
+
+    /// Add the interrupt flag to this event.
+    pub fn set_hup(&mut self) {
+        self.flags |= epoll::EventFlags::HUP;
+    }
+
+    /// Add the priority flag to this event.
+    pub fn set_pri(&mut self) {
+        self.flags |= epoll::EventFlags::PRI;
+    }
+
+    /// Tell if the interrupt flag is set.
+    pub fn is_hup(&self) -> bool {
+        self.flags.contains(epoll::EventFlags::HUP)
+    }
+
+    /// Tell if the priority flag is set.
+    pub fn is_pri(&self) -> bool {
+        self.flags.contains(epoll::EventFlags::PRI)
     }
 }

--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -334,6 +334,7 @@ pub struct EventExtra {
 
 impl EventExtra {
     /// Create an empty version of the data.
+    #[inline]
     pub fn empty() -> EventExtra {
         EventExtra {
             flags: epoll::EventFlags::empty(),
@@ -341,21 +342,25 @@ impl EventExtra {
     }
 
     /// Add the interrupt flag to this event.
-    pub fn set_hup(&mut self) {
-        self.flags |= epoll::EventFlags::HUP;
+    #[inline]
+    pub fn set_hup(&mut self, active: bool) {
+        self.flags.set(epoll::EventFlags::HUP, active);
     }
 
     /// Add the priority flag to this event.
-    pub fn set_pri(&mut self) {
-        self.flags |= epoll::EventFlags::PRI;
+    #[inline]
+    pub fn set_pri(&mut self, active: bool) {
+        self.flags.set(epoll::EventFlags::PRI, active);
     }
 
     /// Tell if the interrupt flag is set.
+    #[inline]
     pub fn is_hup(&self) -> bool {
         self.flags.contains(epoll::EventFlags::HUP)
     }
 
     /// Tell if the priority flag is set.
+    #[inline]
     pub fn is_pri(&self) -> bool {
         self.flags.contains(epoll::EventFlags::PRI)
     }

--- a/src/iocp/afd.rs
+++ b/src/iocp/afd.rs
@@ -89,6 +89,15 @@ impl AfdPollMask {
     pub(crate) fn intersects(self, other: AfdPollMask) -> bool {
         (self.0 & other.0) != 0
     }
+
+    /// Sets a flag.
+    pub(crate) fn set(&mut self, other: AfdPollMask, value: bool) {
+        if value {
+            *self |= other;
+        } else {
+            self.0 &= !other.0;
+        }
+    }
 }
 
 impl fmt::Debug for AfdPollMask {

--- a/src/iocp/afd.rs
+++ b/src/iocp/afd.rs
@@ -134,6 +134,20 @@ impl ops::BitOrAssign for AfdPollMask {
     }
 }
 
+impl ops::BitAnd for AfdPollMask {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self {
+        AfdPollMask(self.0 & rhs.0)
+    }
+}
+
+impl ops::BitAndAssign for AfdPollMask {
+    fn bitand_assign(&mut self, rhs: Self) {
+        self.0 &= rhs.0;
+    }
+}
+
 pub(super) trait HasAfdInfo {
     fn afd_info(self: Pin<&Self>) -> Pin<&UnsafeCell<AfdPollInfo>>;
 }

--- a/src/iocp/afd.rs
+++ b/src/iocp/afd.rs
@@ -66,7 +66,7 @@ impl AfdPollInfo {
     }
 }
 
-#[derive(Default, Copy, Clone)]
+#[derive(Default, Copy, Clone, PartialEq, Eq)]
 #[repr(transparent)]
 pub(super) struct AfdPollMask(u32);
 
@@ -88,6 +88,35 @@ impl AfdPollMask {
     /// Checks if this mask contains the other mask.
     pub(crate) fn intersects(self, other: AfdPollMask) -> bool {
         (self.0 & other.0) != 0
+    }
+}
+
+impl fmt::Debug for AfdPollMask {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        const FLAGS: &[(&str, AfdPollMask)] = &[
+            ("RECEIVE", AfdPollMask::RECEIVE),
+            ("RECEIVE_EXPEDITED", AfdPollMask::RECEIVE_EXPEDITED),
+            ("SEND", AfdPollMask::SEND),
+            ("DISCONNECT", AfdPollMask::DISCONNECT),
+            ("ABORT", AfdPollMask::ABORT),
+            ("LOCAL_CLOSE", AfdPollMask::LOCAL_CLOSE),
+            ("ACCEPT", AfdPollMask::ACCEPT),
+            ("CONNECT_FAIL", AfdPollMask::CONNECT_FAIL),
+        ];
+
+        let mut first = true;
+        for (name, value) in FLAGS {
+            if self.intersects(*value) {
+                if !first {
+                    write!(f, " | ")?;
+                }
+
+                first = false;
+                write!(f, "{}", name)?;
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/src/iocp/mod.rs
+++ b/src/iocp/mod.rs
@@ -781,8 +781,9 @@ impl PacketUnwrapped {
                 // If there was a change, indicate that we need an update.
                 match socket.status {
                     SocketStatus::Polling { flags } => {
-                        let our_flags = event_to_afd_mask(interest.readable, interest.writable, true)
-                            | interest.extra.flags;
+                        let our_flags =
+                            event_to_afd_mask(interest.readable, interest.writable, true)
+                                | interest.extra.flags;
 
                         our_flags != flags
                     }
@@ -799,7 +800,7 @@ impl PacketUnwrapped {
                 // Update if there is no ongoing wait.
                 handle.status.is_idle()
             }
-            _ => true
+            _ => true,
         }
     }
 

--- a/src/iocp/mod.rs
+++ b/src/iocp/mod.rs
@@ -637,6 +637,27 @@ impl Events {
     pub(super) fn clear(&mut self) {
         self.packets.clear();
     }
+
+    /// The capacity of the list of events.
+    pub(super) fn capacity(&self) -> usize {
+        self.packets.capacity()
+    }
+}
+
+/// Extra information about an event.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct EventExtra {
+    /// Flags associated with this event.
+    flags: AfdPollMask,
+}
+
+impl EventExtra {
+    /// Create a new, empty version of this struct.
+    pub fn empty() -> EventExtra {
+        EventExtra {
+            flags: AfdPollMask::empty(),
+        }
+    }
 }
 
 /// A packet used to wake up the poller with an event.

--- a/src/iocp/mod.rs
+++ b/src/iocp/mod.rs
@@ -622,24 +622,24 @@ unsafe impl Send for Events {}
 
 impl Events {
     /// Creates an empty list of events.
-    pub(super) fn with_capacity(cap: usize) -> Events {
+    pub fn with_capacity(cap: usize) -> Events {
         Events {
             packets: Vec::with_capacity(cap),
         }
     }
 
     /// Iterate over I/O events.
-    pub(super) fn iter(&self) -> impl Iterator<Item = Event> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = Event> + '_ {
         self.packets.iter().copied()
     }
 
     /// Clear the list of events.
-    pub(super) fn clear(&mut self) {
+    pub fn clear(&mut self) {
         self.packets.clear();
     }
 
     /// The capacity of the list of events.
-    pub(super) fn capacity(&self) -> usize {
+    pub fn capacity(&self) -> usize {
         self.packets.capacity()
     }
 }
@@ -653,6 +653,7 @@ pub struct EventExtra {
 
 impl EventExtra {
     /// Create a new, empty version of this struct.
+    #[inline]
     pub fn empty() -> EventExtra {
         EventExtra {
             flags: AfdPollMask::empty(),
@@ -660,23 +661,27 @@ impl EventExtra {
     }
 
     /// Is this a HUP event?
+    #[inline]
     pub fn is_hup(&self) -> bool {
         self.flags.intersects(AfdPollMask::ABORT)
     }
 
     /// Is this a PRI event?
+    #[inline]
     pub fn is_pri(&self) -> bool {
         self.flags.intersects(AfdPollMask::RECEIVE_EXPEDITED)
     }
 
     /// Set up a listener for HUP events.
-    pub fn set_hup(&mut self) {
-        self.flags |= AfdPollMask::ABORT;
+    #[inline]
+    pub fn set_hup(&mut self, active: bool) {
+        self.flags.set(AfdPollMask::ABORT, active);
     }
 
     /// Set up a listener for PRI events.
-    pub fn set_pri(&mut self) {
-        self.flags |= AfdPollMask::RECEIVE_EXPEDITED;
+    #[inline]
+    pub fn set_pri(&mut self, active: bool) {
+        self.flags.set(AfdPollMask::RECEIVE_EXPEDITED, active);
     }
 }
 

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -222,9 +222,9 @@ unsafe impl Send for Events {}
 
 impl Events {
     /// Creates an empty list.
-    pub fn new() -> Events {
+    pub fn with_capacity(cap: usize) -> Events {
         Events {
-            list: Vec::with_capacity(1024),
+            list: Vec::with_capacity(cap),
         }
     }
 
@@ -248,6 +248,16 @@ impl Events {
                 || (matches!(ev.filter(), kqueue::EventFilter::Read(..))
                     && (ev.flags().intersects(kqueue::EventFlags::EOF))),
         })
+    }
+
+    /// Clears the list.
+    pub fn clear(&mut self) {
+        self.list.clear();
+    }
+
+    /// Get the capacity of the list.
+    pub fn capacity(&self) -> usize {
+        self.list.capacity()
     }
 }
 

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -247,6 +247,7 @@ impl Events {
             writable: matches!(ev.filter(), kqueue::EventFilter::Write(..))
                 || (matches!(ev.filter(), kqueue::EventFilter::Read(..))
                     && (ev.flags().intersects(kqueue::EventFlags::EOF))),
+            extra: EventExtra,
         })
     }
 
@@ -258,6 +259,17 @@ impl Events {
     /// Get the capacity of the list.
     pub fn capacity(&self) -> usize {
         self.list.capacity()
+    }
+}
+
+/// Extra information associated with an event.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct EventExtra;
+
+impl EventExtra {
+    /// Create a new, empty version of this struct.
+    pub fn empty() -> EventExtra {
+        EventExtra
     }
 }
 

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -271,6 +271,26 @@ impl EventExtra {
     pub fn empty() -> EventExtra {
         EventExtra
     }
+
+    /// Set the interrupt flag.
+    pub fn set_hup(&mut self) {
+        // No-op.
+    }
+
+    /// Set the priority flag.
+    pub fn set_pri(&mut self) {
+        // No-op.
+    }
+
+    /// Is the interrupt flag set?
+    pub fn is_hup(&self) -> bool {
+        false
+    }
+
+    /// Is the priority flag set?
+    pub fn is_pri(&self) -> bool {
+        false
+    }
 }
 
 pub(crate) fn mode_to_flags(mode: PollMode) -> kqueue::EventFlags {

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -268,26 +268,31 @@ pub struct EventExtra;
 
 impl EventExtra {
     /// Create a new, empty version of this struct.
+    #[inline]
     pub fn empty() -> EventExtra {
         EventExtra
     }
 
     /// Set the interrupt flag.
-    pub fn set_hup(&mut self) {
+    #[inline]
+    pub fn set_hup(&mut self, _value: bool) {
         // No-op.
     }
 
     /// Set the priority flag.
-    pub fn set_pri(&mut self) {
+    #[inline]
+    pub fn set_pri(&mut self, _value: bool) {
         // No-op.
     }
 
     /// Is the interrupt flag set?
+    #[inline]
     pub fn is_hup(&self) -> bool {
         false
     }
 
     /// Is the priority flag set?
+    #[inline]
     pub fn is_pri(&self) -> bool {
         false
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! # Examples
 //!
 //! ```no_run
-//! use polling::{Event, Poller};
+//! use polling::{Event, Events, Poller};
 //! use std::net::TcpListener;
 //!
 //! // Create a TCP listener.
@@ -33,13 +33,13 @@
 //! }
 //!
 //! // The event loop.
-//! let mut events = Vec::new();
+//! let mut events = Events::new();
 //! loop {
 //!     // Wait for at least one I/O event.
 //!     events.clear();
 //!     poller.wait(&mut events, None)?;
 //!
-//!     for ev in &events {
+//!     for ev in events.iter() {
 //!         if ev.key == key {
 //!             // Perform a non-blocking accept operation.
 //!             socket.accept()?;
@@ -603,7 +603,7 @@ impl Poller {
     /// # Examples
     ///
     /// ```
-    /// use polling::{Event, Poller};
+    /// use polling::{Event, Events, Poller};
     /// use std::net::TcpListener;
     /// use std::time::Duration;
     ///
@@ -616,7 +616,7 @@ impl Poller {
     ///     poller.add(&socket, Event::all(key))?;
     /// }
     ///
-    /// let mut events = Vec::new();
+    /// let mut events = Events::new();
     /// let n = poller.wait(&mut events, Some(Duration::from_secs(1)))?;
     /// poller.delete(&socket)?;
     /// # std::io::Result::Ok(())
@@ -650,14 +650,14 @@ impl Poller {
     /// # Examples
     ///
     /// ```
-    /// use polling::Poller;
+    /// use polling::{Events, Poller};
     ///
     /// let poller = Poller::new()?;
     ///
     /// // Notify the poller.
     /// poller.notify()?;
     ///
-    /// let mut events = Vec::new();
+    /// let mut events = Events::new();
     /// poller.wait(&mut events, None)?; // wakes up immediately
     /// assert!(events.is_empty());
     /// # std::io::Result::Ok(())
@@ -804,7 +804,7 @@ impl Events {
     /// ```
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.len() != 0
+        self.len() == 0
     }
 
     /// Get the total capacity of the list.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,110 @@ impl Event {
             extra: sys::EventExtra::empty(),
         }
     }
+
+    /// Add interruption events to this interest.
+    ///
+    /// This usually indicates that the file descriptor or socket has been closed. It corresponds
+    /// to the `EPOLLHUP` and `POLLHUP` events.
+    ///
+    /// Interruption events are only supported on the following platforms:
+    ///
+    /// - `epoll`
+    /// - `poll`
+    /// - IOCP
+    /// - Event Ports
+    ///
+    /// On other platforms, this function is a no-op.
+    pub fn set_interrupt(&mut self) {
+        self.extra.set_hup();
+    }
+
+    /// Add interruption events to this interest.
+    ///
+    /// This usually indicates that the file descriptor or socket has been closed. It corresponds
+    /// to the `EPOLLHUP` and `POLLHUP` events.
+    ///
+    /// Interruption events are only supported on the following platforms:
+    ///
+    /// - `epoll`
+    /// - `poll`
+    /// - IOCP
+    /// - Event Ports
+    ///
+    /// On other platforms, this function is a no-op.
+    pub fn with_interrupt(mut self) -> Self {
+        self.set_interrupt();
+        self
+    }
+
+    /// Add priority events to this interest.
+    ///
+    /// This indicates that there is urgent data to read. It corresponds to the `EPOLLPRI` and
+    /// `POLLPRI` events.
+    ///
+    /// Priority events are only supported on the following platforms:
+    ///
+    /// - `epoll`
+    /// - `poll`
+    /// - IOCP
+    /// - Event Ports
+    ///
+    /// On other platforms, this function is a no-op.
+    pub fn set_priority(&mut self) {
+        self.extra.set_pri();
+    }
+
+    /// Add priority events to this interest.
+    ///
+    /// This indicates that there is urgent data to read. It corresponds to the `EPOLLPRI` and
+    /// `POLLPRI` events.
+    ///
+    /// Priority events are only supported on the following platforms:
+    ///
+    /// - `epoll`
+    /// - `poll`
+    /// - IOCP
+    /// - Event Ports
+    ///
+    /// On other platforms, this function is a no-op.
+    pub fn with_priority(mut self) -> Self {
+        self.set_priority();
+        self
+    }
+
+    /// Tell if this event is the result of an interrupt notification.
+    ///
+    /// This usually indicates that the file descriptor or socket has been closed. It corresponds
+    /// to the `EPOLLHUP` and `POLLHUP` events.
+    ///
+    /// Interruption events are only supported on the following platforms:
+    ///
+    /// - `epoll`
+    /// - `poll`
+    /// - IOCP
+    /// - Event Ports
+    ///
+    /// On other platforms, this always returns `false`.
+    pub fn is_interrupt(&self) -> bool {
+        self.extra.is_hup()
+    }
+
+    /// Tell if this event is the result of a priority notification.
+    ///
+    /// This indicates that there is urgent data to read. It corresponds to the `EPOLLPRI` and
+    /// `POLLPRI` events.
+    ///
+    /// Priority events are only supported on the following platforms:
+    ///
+    /// - `epoll`
+    /// - `poll`
+    /// - IOCP
+    /// - Event Ports
+    ///
+    /// On other platforms, this always returns `false`.
+    pub fn is_priority(&self) -> bool {
+        self.extra.is_pri()
+    }
 }
 
 /// Waits for I/O events.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,8 @@ pub struct Event {
     pub readable: bool,
     /// Can it do a write operation without blocking?
     pub writable: bool,
+    /// System-specific event data.
+    extra: sys::EventExtra,
 }
 
 /// The mode in which the poller waits for I/O events.
@@ -187,6 +189,7 @@ impl Event {
             key,
             readable: true,
             writable: true,
+            extra: sys::EventExtra::empty(),
         }
     }
 
@@ -198,6 +201,7 @@ impl Event {
             key,
             readable: true,
             writable: false,
+            extra: sys::EventExtra::empty(),
         }
     }
 
@@ -209,6 +213,7 @@ impl Event {
             key,
             readable: false,
             writable: true,
+            extra: sys::EventExtra::empty(),
         }
     }
 
@@ -220,6 +225,7 @@ impl Event {
             key,
             readable: false,
             writable: false,
+            extra: sys::EventExtra::empty(),
         }
     }
 }

--- a/src/os/iocp.rs
+++ b/src/os/iocp.rs
@@ -19,7 +19,7 @@ pub trait PollerIocpExt: PollerSealed {
     /// # Examples
     ///
     /// ```rust
-    /// use polling::{Poller, Event};
+    /// use polling::{Poller, Event, Events};
     /// use polling::os::iocp::{CompletionPacket, PollerIocpExt};
     ///
     /// use std::thread;
@@ -39,7 +39,7 @@ pub trait PollerIocpExt: PollerSealed {
     /// });
     ///
     /// // Wait for the event.
-    /// let mut events = vec![];
+    /// let mut events = Events::new();
     /// poller.wait(&mut events, None)?;
     ///
     /// assert_eq!(events.len(), 1);
@@ -72,7 +72,7 @@ pub trait PollerIocpExt: PollerSealed {
     /// # Examples
     ///
     /// ```no_run
-    /// use polling::{Poller, Event, PollMode};
+    /// use polling::{Poller, Event, Events, PollMode};
     /// use polling::os::iocp::PollerIocpExt;
     ///
     /// use std::process::Command;
@@ -92,11 +92,11 @@ pub trait PollerIocpExt: PollerSealed {
     /// }
     ///
     /// // Wait for the child process to exit.
-    /// let mut events = vec![];
+    /// let mut events = Events::new();
     /// poller.wait(&mut events, None).unwrap();
     ///
     /// assert_eq!(events.len(), 1);
-    /// assert_eq!(events[0], Event::all(0));
+    /// assert_eq!(events.iter().next().unwrap(), Event::all(0));
     /// ```
     unsafe fn add_waitable(
         &self,
@@ -115,7 +115,7 @@ pub trait PollerIocpExt: PollerSealed {
     /// # Examples
     ///
     /// ```no_run
-    /// use polling::{Poller, Event, PollMode};
+    /// use polling::{Poller, Event, Events, PollMode};
     /// use polling::os::iocp::PollerIocpExt;
     ///
     /// use std::process::Command;
@@ -135,11 +135,11 @@ pub trait PollerIocpExt: PollerSealed {
     /// }
     ///
     /// // Wait for the child process to exit.
-    /// let mut events = vec![];
+    /// let mut events = Events::new();
     /// poller.wait(&mut events, None).unwrap();
     ///
     /// assert_eq!(events.len(), 1);
-    /// assert_eq!(events[0], Event::all(0));
+    /// assert_eq!(events.iter().next().unwrap(), Event::all(0));
     ///
     /// // Modify the waitable handle.
     /// poller.modify_waitable(&child, Event::readable(0), PollMode::Oneshot).unwrap();
@@ -161,7 +161,7 @@ pub trait PollerIocpExt: PollerSealed {
     /// # Examples
     ///
     /// ```no_run
-    /// use polling::{Poller, Event, PollMode};
+    /// use polling::{Poller, Event, Events, PollMode};
     /// use polling::os::iocp::PollerIocpExt;
     ///
     /// use std::process::Command;
@@ -181,11 +181,11 @@ pub trait PollerIocpExt: PollerSealed {
     /// }
     ///
     /// // Wait for the child process to exit.
-    /// let mut events = vec![];
+    /// let mut events = Events::new();
     /// poller.wait(&mut events, None).unwrap();
     ///
     /// assert_eq!(events.len(), 1);
-    /// assert_eq!(events[0], Event::all(0));
+    /// assert_eq!(events.iter().next().unwrap(), Event::all(0));
     ///
     /// // Remove the waitable handle.
     /// poller.remove_waitable(&child).unwrap();

--- a/src/os/kqueue.rs
+++ b/src/os/kqueue.rs
@@ -31,7 +31,7 @@ pub trait PollerKqueueExt<F: Filter>: PollerSealed {
     /// # Examples
     ///
     /// ```no_run
-    /// use polling::{Poller, PollMode};
+    /// use polling::{Events, Poller, PollMode};
     /// use polling::os::kqueue::{Filter, PollerKqueueExt, Signal};
     ///
     /// let poller = Poller::new().unwrap();
@@ -40,7 +40,7 @@ pub trait PollerKqueueExt<F: Filter>: PollerSealed {
     /// poller.add_filter(Signal(libc::SIGINT), 0, PollMode::Oneshot).unwrap();
     ///
     /// // Wait for the signal.
-    /// let mut events = vec![];
+    /// let mut events = Events::new();
     /// poller.wait(&mut events, None).unwrap();
     /// # let _ = events;
     /// ```
@@ -54,7 +54,7 @@ pub trait PollerKqueueExt<F: Filter>: PollerSealed {
     /// # Examples
     ///
     /// ```no_run
-    /// use polling::{Poller, PollMode};
+    /// use polling::{Events, Poller, PollMode};
     /// use polling::os::kqueue::{Filter, PollerKqueueExt, Signal};
     ///
     /// let poller = Poller::new().unwrap();
@@ -66,7 +66,7 @@ pub trait PollerKqueueExt<F: Filter>: PollerSealed {
     /// poller.modify_filter(Signal(libc::SIGINT), 1, PollMode::Oneshot).unwrap();
     ///
     /// // Wait for the signal.
-    /// let mut events = vec![];
+    /// let mut events = Events::new();
     /// poller.wait(&mut events, None).unwrap();
     /// # let _ = events;
     /// ```
@@ -183,7 +183,12 @@ pub enum ProcessOps {
 
 impl<'a> Process<'a> {
     /// Monitor a child process.
-    pub fn new(child: &'a Child, ops: ProcessOps) -> Self {
+    ///
+    /// # Safety
+    ///
+    /// Once registered into the `Poller`, the `Child` object must outlive this filter's
+    /// registration into the poller.
+    pub unsafe fn new(child: &'a Child, ops: ProcessOps) -> Self {
         Self { child, ops }
     }
 }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -397,6 +397,7 @@ pub struct EventExtra {
 
 impl EventExtra {
     /// Creates an empty set of extra information.
+    #[inline]
     pub fn empty() -> Self {
         Self {
             flags: PollFlags::empty(),
@@ -404,21 +405,25 @@ impl EventExtra {
     }
 
     /// Set the interrupt flag.
-    pub fn set_hup(&mut self) {
-        self.flags.set(PollFlags::HUP, true);
+    #[inline]
+    pub fn set_hup(&mut self, value: bool) {
+        self.flags.set(PollFlags::HUP, value);
     }
 
     /// Set the priority flag.
-    pub fn set_pri(&mut self) {
-        self.flags.set(PollFlags::PRI, true);
+    #[inline]
+    pub fn set_pri(&mut self, value: bool) {
+        self.flags.set(PollFlags::PRI, value);
     }
 
     /// Is this an interrupt event?
+    #[inline]
     pub fn is_hup(&self) -> bool {
         self.flags.contains(PollFlags::HUP)
     }
 
     /// Is this a priority event?
+    #[inline]
     pub fn is_pri(&self) -> bool {
         self.flags.contains(PollFlags::PRI)
     }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -402,6 +402,26 @@ impl EventExtra {
             flags: PollFlags::empty(),
         }
     }
+
+    /// Set the interrupt flag.
+    pub fn set_hup(&mut self) {
+        self.flags.set(PollFlags::HUP, true);
+    }
+
+    /// Set the priority flag.
+    pub fn set_pri(&mut self) {
+        self.flags.set(PollFlags::PRI, true);
+    }
+
+    /// Is this an interrupt event?
+    pub fn is_hup(&self) -> bool {
+        self.flags.contains(PollFlags::HUP)
+    }
+
+    /// Is this a priority event?
+    pub fn is_pri(&self) -> bool {
+        self.flags.contains(PollFlags::PRI)
+    }
 }
 
 fn cvt_mode_as_remove(mode: PollMode) -> io::Result<bool> {

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -364,13 +364,23 @@ pub struct Events {
 
 impl Events {
     /// Creates an empty list.
-    pub fn new() -> Events {
-        Self { inner: Vec::new() }
+    pub fn with_capacity(cap: usize) -> Events {
+        Self { inner: Vec::with_capacity(cap) }
     }
 
     /// Iterates over I/O events.
     pub fn iter(&self) -> impl Iterator<Item = Event> + '_ {
         self.inner.iter().copied()
+    }
+
+    /// Clear the list.
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+
+    /// Get the capacity of the list.
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity()
     }
 }
 

--- a/src/port.rs
+++ b/src/port.rs
@@ -220,6 +220,7 @@ pub struct EventExtra {
 
 impl EventExtra {
     /// Create a new, empty version of this struct.
+    #[inline]
     pub fn empty() -> EventExtra {
         EventExtra {
             flags: PollFlags::empty(),
@@ -227,21 +228,25 @@ impl EventExtra {
     }
 
     /// Set the interrupt flag.
-    pub fn set_hup(&mut self) {
-        self.flags.set(PollFlags::HUP, true);
+    #[inline]
+    pub fn set_hup(&mut self, value: bool) {
+        self.flags.set(PollFlags::HUP, value);
     }
 
     /// Set the priority flag.
-    pub fn set_pri(&mut self) {
-        self.flags.set(PollFlags::PRI, true);
+    #[inline]
+    pub fn set_pri(&mut self, value: bool) {
+        self.flags.set(PollFlags::PRI, value);
     }
 
     /// Is this an interrupt event?
+    #[inline]
     pub fn is_hup(&self) -> bool {
         self.flags.contains(PollFlags::HUP)
     }
 
     /// Is this a priority event?
+    #[inline]
     pub fn is_pri(&self) -> bool {
         self.flags.contains(PollFlags::PRI)
     }

--- a/src/port.rs
+++ b/src/port.rs
@@ -181,9 +181,9 @@ unsafe impl Send for Events {}
 
 impl Events {
     /// Creates an empty list.
-    pub fn new() -> Events {
+    pub fn with_capacity(cap: usize) -> Events {
         Events {
-            list: Vec::with_capacity(1024),
+            list: Vec::with_capacity(cap),
         }
     }
 
@@ -194,5 +194,15 @@ impl Events {
             readable: PollFlags::from_bits_truncate(ev.events() as _).intersects(read_flags()),
             writable: PollFlags::from_bits_truncate(ev.events() as _).intersects(write_flags()),
         })
+    }
+
+    /// Clear the list.
+    pub fn clear(&mut self) {
+        self.list.clear();
+    }
+
+    /// Get the capacity of the list.
+    pub fn capacity(&self) -> usize {
+        self.list.capacity()
     }
 }

--- a/src/port.rs
+++ b/src/port.rs
@@ -225,4 +225,24 @@ impl EventExtra {
             flags: PollFlags::empty(),
         }
     }
+
+    /// Set the interrupt flag.
+    pub fn set_hup(&mut self) {
+        self.flags.set(PollFlags::HUP, true);
+    }
+
+    /// Set the priority flag.
+    pub fn set_pri(&mut self) {
+        self.flags.set(PollFlags::PRI, true);
+    }
+
+    /// Is this an interrupt event?
+    pub fn is_hup(&self) -> bool {
+        self.flags.contains(PollFlags::HUP)
+    }
+
+    /// Is this a priority event?
+    pub fn is_pri(&self) -> bool {
+        self.flags.contains(PollFlags::PRI)
+    }
 }

--- a/tests/concurrent_modification.rs
+++ b/tests/concurrent_modification.rs
@@ -33,7 +33,9 @@ fn concurrent_add() -> io::Result<()> {
     poller.delete(&reader)?;
     result?;
 
-    assert_eq!(events.iter().collect::<Vec<_>>(), [Event::readable(0)]);
+    assert_eq!(events.len(), 1);
+    assert!(events.iter().next().unwrap().readable);
+    assert!(!events.iter().next().unwrap().writable);
 
     Ok(())
 }
@@ -63,7 +65,9 @@ fn concurrent_modify() -> io::Result<()> {
         .into_iter()
         .collect::<io::Result<()>>()?;
 
-    assert_eq!(events.iter().collect::<Vec<_>>(), [Event::readable(0)]);
+    assert_eq!(events.len(), 1);
+    assert!(events.iter().next().unwrap().readable);
+    assert!(!events.iter().next().unwrap().writable);
 
     Ok(())
 }

--- a/tests/concurrent_modification.rs
+++ b/tests/concurrent_modification.rs
@@ -34,8 +34,10 @@ fn concurrent_add() -> io::Result<()> {
     result?;
 
     assert_eq!(events.len(), 1);
-    assert!(events.iter().next().unwrap().readable);
-    assert!(!events.iter().next().unwrap().writable);
+    assert_eq!(
+        events.iter().next().unwrap().with_no_extra(),
+        Event::readable(0)
+    );
 
     Ok(())
 }
@@ -66,8 +68,10 @@ fn concurrent_modify() -> io::Result<()> {
         .collect::<io::Result<()>>()?;
 
     assert_eq!(events.len(), 1);
-    assert!(events.iter().next().unwrap().readable);
-    assert!(!events.iter().next().unwrap().writable);
+    assert_eq!(
+        events.iter().next().unwrap().with_no_extra(),
+        Event::readable(0)
+    );
 
     Ok(())
 }

--- a/tests/concurrent_modification.rs
+++ b/tests/concurrent_modification.rs
@@ -4,14 +4,14 @@ use std::thread;
 use std::time::Duration;
 
 use easy_parallel::Parallel;
-use polling::{Event, Poller};
+use polling::{Event, Events, Poller};
 
 #[test]
 fn concurrent_add() -> io::Result<()> {
     let (reader, mut writer) = tcp_pair()?;
     let poller = Poller::new()?;
 
-    let mut events = Vec::new();
+    let mut events = Events::new();
 
     let result = Parallel::new()
         .add(|| {
@@ -33,7 +33,7 @@ fn concurrent_add() -> io::Result<()> {
     poller.delete(&reader)?;
     result?;
 
-    assert_eq!(events, [Event::readable(0)]);
+    assert_eq!(events.iter().collect::<Vec<_>>(), [Event::readable(0)]);
 
     Ok(())
 }
@@ -46,7 +46,7 @@ fn concurrent_modify() -> io::Result<()> {
         poller.add(&reader, Event::none(0))?;
     }
 
-    let mut events = Vec::new();
+    let mut events = Events::new();
 
     Parallel::new()
         .add(|| {
@@ -63,7 +63,7 @@ fn concurrent_modify() -> io::Result<()> {
         .into_iter()
         .collect::<io::Result<()>>()?;
 
-    assert_eq!(events, [Event::readable(0)]);
+    assert_eq!(events.iter().collect::<Vec<_>>(), [Event::readable(0)]);
 
     Ok(())
 }

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -29,7 +29,10 @@ fn basic_io() {
             .unwrap(),
         1
     );
-    assert_eq!(events.iter().collect::<Vec<_>>(), &[Event::readable(1)]);
+
+    assert_eq!(events.len(), 1);
+    assert!(events.iter().next().unwrap().readable);
+    assert!(!events.iter().next().unwrap().writable);
 
     poller.delete(&read).unwrap();
 }

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -1,4 +1,4 @@
-use polling::{Event, Poller};
+use polling::{Event, Events, Poller};
 use std::io::{self, Write};
 use std::net::{TcpListener, TcpStream};
 use std::time::Duration;
@@ -12,7 +12,7 @@ fn basic_io() {
     }
 
     // Nothing should be available at first.
-    let mut events = vec![];
+    let mut events = Events::new();
     assert_eq!(
         poller
             .wait(&mut events, Some(Duration::from_secs(0)))
@@ -29,7 +29,7 @@ fn basic_io() {
             .unwrap(),
         1
     );
-    assert_eq!(&*events, &[Event::readable(1)]);
+    assert_eq!(events.iter().collect::<Vec<_>>(), &[Event::readable(1)]);
 
     poller.delete(&read).unwrap();
 }

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -31,9 +31,10 @@ fn basic_io() {
     );
 
     assert_eq!(events.len(), 1);
-    assert!(events.iter().next().unwrap().readable);
-    assert!(!events.iter().next().unwrap().writable);
-
+    assert_eq!(
+        events.iter().next().unwrap().with_no_extra(),
+        Event::readable(1)
+    );
     poller.delete(&read).unwrap();
 }
 

--- a/tests/many_connections.rs
+++ b/tests/many_connections.rs
@@ -7,6 +7,8 @@ use std::io::{self, prelude::*};
 use std::net::{TcpListener, TcpStream};
 use std::time::Duration;
 
+use polling::Events;
+
 #[test]
 fn many_connections() {
     // Create 100 connections.
@@ -25,7 +27,7 @@ fn many_connections() {
         }
     }
 
-    let mut events = vec![];
+    let mut events = Events::new();
     while !connections.is_empty() {
         // Choose a random connection to write to.
         let i = fastrand::usize(..connections.len());
@@ -40,10 +42,11 @@ fn many_connections() {
             .unwrap();
 
         // Check that the connection is readable.
-        assert_eq!(events.len(), 1, "events: {:?}", events);
-        assert_eq!(events[0].key, id);
-        assert!(events[0].readable);
-        assert!(!events[0].writable);
+        let current_events = events.iter().collect::<Vec<_>>();
+        assert_eq!(current_events.len(), 1, "events: {:?}", current_events);
+        assert_eq!(current_events[0].key, id);
+        assert!(current_events[0].readable);
+        assert!(!current_events[0].writable);
 
         // Read the byte from the connection.
         let mut buf = [0];

--- a/tests/many_connections.rs
+++ b/tests/many_connections.rs
@@ -44,9 +44,10 @@ fn many_connections() {
         // Check that the connection is readable.
         let current_events = events.iter().collect::<Vec<_>>();
         assert_eq!(current_events.len(), 1, "events: {:?}", current_events);
-        assert_eq!(current_events[0].key, id);
-        assert!(current_events[0].readable);
-        assert!(!current_events[0].writable);
+        assert_eq!(
+            current_events[0].with_no_extra(),
+            polling::Event::readable(id)
+        );
 
         // Read the byte from the connection.
         let mut buf = [0];

--- a/tests/notify.rs
+++ b/tests/notify.rs
@@ -14,6 +14,7 @@ fn simple() -> io::Result<()> {
     for _ in 0..10 {
         poller.notify()?;
         poller.wait(&mut events, None)?;
+        assert!(events.is_empty());
     }
 
     Ok(())

--- a/tests/notify.rs
+++ b/tests/notify.rs
@@ -3,12 +3,13 @@ use std::thread;
 use std::time::Duration;
 
 use easy_parallel::Parallel;
+use polling::Events;
 use polling::Poller;
 
 #[test]
 fn simple() -> io::Result<()> {
     let poller = Poller::new()?;
-    let mut events = Vec::new();
+    let mut events = Events::new();
 
     for _ in 0..10 {
         poller.notify()?;
@@ -21,7 +22,7 @@ fn simple() -> io::Result<()> {
 #[test]
 fn concurrent() -> io::Result<()> {
     let poller = Poller::new()?;
-    let mut events = Vec::new();
+    let mut events = Events::new();
 
     for _ in 0..2 {
         Parallel::new()

--- a/tests/other_modes.rs
+++ b/tests/other_modes.rs
@@ -40,9 +40,10 @@ fn level_triggered() {
         .unwrap();
 
     assert_eq!(events.len(), 1);
-    assert_eq!(events.iter().next().unwrap().key, reader_token);
-    assert!(events.iter().next().unwrap().readable);
-    assert!(!events.iter().next().unwrap().writable);
+    assert_eq!(
+        events.iter().next().unwrap().with_no_extra(),
+        Event::readable(reader_token)
+    );
 
     // If we read some of the data, the notification should still be available.
     reader.read_exact(&mut [0; 3]).unwrap();
@@ -52,9 +53,10 @@ fn level_triggered() {
         .unwrap();
 
     assert_eq!(events.len(), 1);
-    assert_eq!(events.iter().next().unwrap().key, reader_token);
-    assert!(events.iter().next().unwrap().readable);
-    assert!(!events.iter().next().unwrap().writable);
+    assert_eq!(
+        events.iter().next().unwrap().with_no_extra(),
+        Event::readable(reader_token)
+    );
 
     // If we read the rest of the data, the notification should be gone.
     reader.read_exact(&mut [0; 2]).unwrap();
@@ -63,7 +65,7 @@ fn level_triggered() {
         .wait(&mut events, Some(Duration::from_secs(0)))
         .unwrap();
 
-    assert_eq!(events.iter().collect::<Vec<_>>(), []);
+    assert!(events.is_empty());
 
     // After modifying the stream and sending more data, it should be oneshot.
     poller
@@ -79,9 +81,10 @@ fn level_triggered() {
         .unwrap();
 
     assert_eq!(events.len(), 1);
-    assert_eq!(events.iter().next().unwrap().key, reader_token);
-    assert!(events.iter().next().unwrap().readable);
-    assert!(!events.iter().next().unwrap().writable);
+    assert_eq!(
+        events.iter().next().unwrap().with_no_extra(),
+        Event::readable(reader_token)
+    );
 
     // After reading, the notification should vanish.
     reader.read(&mut [0; 5]).unwrap();
@@ -90,7 +93,7 @@ fn level_triggered() {
         .wait(&mut events, Some(Duration::from_secs(0)))
         .unwrap();
 
-    assert_eq!(events.iter().collect::<Vec<_>>(), []);
+    assert!(events.is_empty());
 }
 
 #[test]
@@ -139,9 +142,10 @@ fn edge_triggered() {
         .unwrap();
 
     assert_eq!(events.len(), 1);
-    assert_eq!(events.iter().next().unwrap().key, reader_token);
-    assert!(events.iter().next().unwrap().readable);
-    assert!(!events.iter().next().unwrap().writable);
+    assert_eq!(
+        events.iter().next().unwrap().with_no_extra(),
+        Event::readable(reader_token)
+    );
 
     // If we read some of the data, the notification should not still be available.
     reader.read_exact(&mut [0; 3]).unwrap();
@@ -149,7 +153,7 @@ fn edge_triggered() {
     poller
         .wait(&mut events, Some(Duration::from_secs(0)))
         .unwrap();
-    assert_eq!(events.iter().collect::<Vec<_>>(), []);
+    assert!(events.is_empty());
 
     // If we write more data, a notification should be delivered.
     writer.write_all(&data).unwrap();
@@ -159,9 +163,10 @@ fn edge_triggered() {
         .unwrap();
 
     assert_eq!(events.len(), 1);
-    assert_eq!(events.iter().next().unwrap().key, reader_token);
-    assert!(events.iter().next().unwrap().readable);
-    assert!(!events.iter().next().unwrap().writable);
+    assert_eq!(
+        events.iter().next().unwrap().with_no_extra(),
+        Event::readable(reader_token)
+    );
 
     // After modifying the stream and sending more data, it should be oneshot.
     poller
@@ -175,9 +180,10 @@ fn edge_triggered() {
         .unwrap();
 
     assert_eq!(events.len(), 1);
-    assert_eq!(events.iter().next().unwrap().key, reader_token);
-    assert!(events.iter().next().unwrap().readable);
-    assert!(!events.iter().next().unwrap().writable);
+    assert_eq!(
+        events.iter().next().unwrap().with_no_extra(),
+        Event::readable(reader_token)
+    );
 }
 
 #[test]
@@ -232,8 +238,10 @@ fn edge_oneshot_triggered() {
         .unwrap();
 
     assert_eq!(events.len(), 1);
-    assert!(events.iter().next().unwrap().readable);
-    assert!(!events.iter().next().unwrap().writable);
+    assert_eq!(
+        events.iter().next().unwrap().with_no_extra(),
+        Event::readable(reader_token)
+    );
 
     // If we read some of the data, the notification should not still be available.
     reader.read_exact(&mut [0; 3]).unwrap();
@@ -257,8 +265,10 @@ fn edge_oneshot_triggered() {
         .unwrap();
 
     assert_eq!(events.len(), 1);
-    assert!(events.iter().next().unwrap().readable);
-    assert!(!events.iter().next().unwrap().writable);
+    assert_eq!(
+        events.iter().next().unwrap().with_no_extra(),
+        Event::readable(reader_token)
+    );
 }
 
 fn tcp_pair() -> io::Result<(TcpStream, TcpStream)> {

--- a/tests/other_modes.rs
+++ b/tests/other_modes.rs
@@ -6,7 +6,7 @@ use std::io::{self, prelude::*};
 use std::net::{TcpListener, TcpStream};
 use std::time::Duration;
 
-use polling::{Event, PollMode, Poller};
+use polling::{Event, Events, PollMode, Poller};
 
 #[test]
 fn level_triggered() {
@@ -34,12 +34,15 @@ fn level_triggered() {
     writer.write_all(&data).unwrap();
 
     // A "readable" notification should be delivered.
-    let mut events = Vec::new();
+    let mut events = Events::new();
     poller
         .wait(&mut events, Some(Duration::from_secs(10)))
         .unwrap();
 
-    assert_eq!(events, [Event::readable(reader_token)]);
+    assert_eq!(
+        events.iter().collect::<Vec<_>>(),
+        [Event::readable(reader_token)]
+    );
 
     // If we read some of the data, the notification should still be available.
     reader.read_exact(&mut [0; 3]).unwrap();
@@ -47,7 +50,10 @@ fn level_triggered() {
     poller
         .wait(&mut events, Some(Duration::from_secs(10)))
         .unwrap();
-    assert_eq!(events, [Event::readable(reader_token)]);
+    assert_eq!(
+        events.iter().collect::<Vec<_>>(),
+        [Event::readable(reader_token)]
+    );
 
     // If we read the rest of the data, the notification should be gone.
     reader.read_exact(&mut [0; 2]).unwrap();
@@ -56,7 +62,7 @@ fn level_triggered() {
         .wait(&mut events, Some(Duration::from_secs(0)))
         .unwrap();
 
-    assert_eq!(events, []);
+    assert_eq!(events.iter().collect::<Vec<_>>(), []);
 
     // After modifying the stream and sending more data, it should be oneshot.
     poller
@@ -71,7 +77,10 @@ fn level_triggered() {
         .wait(&mut events, Some(Duration::from_secs(10)))
         .unwrap();
 
-    assert_eq!(events, [Event::readable(reader_token)]);
+    assert_eq!(
+        events.iter().collect::<Vec<_>>(),
+        [Event::readable(reader_token)]
+    );
 
     // After reading, the notification should vanish.
     reader.read(&mut [0; 5]).unwrap();
@@ -80,7 +89,7 @@ fn level_triggered() {
         .wait(&mut events, Some(Duration::from_secs(0)))
         .unwrap();
 
-    assert_eq!(events, []);
+    assert_eq!(events.iter().collect::<Vec<_>>(), []);
 }
 
 #[test]
@@ -123,12 +132,15 @@ fn edge_triggered() {
     writer.write_all(&data).unwrap();
 
     // A "readable" notification should be delivered.
-    let mut events = Vec::new();
+    let mut events = Events::new();
     poller
         .wait(&mut events, Some(Duration::from_secs(10)))
         .unwrap();
 
-    assert_eq!(events, [Event::readable(reader_token)]);
+    assert_eq!(
+        events.iter().collect::<Vec<_>>(),
+        [Event::readable(reader_token)]
+    );
 
     // If we read some of the data, the notification should not still be available.
     reader.read_exact(&mut [0; 3]).unwrap();
@@ -136,7 +148,7 @@ fn edge_triggered() {
     poller
         .wait(&mut events, Some(Duration::from_secs(0)))
         .unwrap();
-    assert_eq!(events, []);
+    assert_eq!(events.iter().collect::<Vec<_>>(), []);
 
     // If we write more data, a notification should be delivered.
     writer.write_all(&data).unwrap();
@@ -144,7 +156,10 @@ fn edge_triggered() {
     poller
         .wait(&mut events, Some(Duration::from_secs(10)))
         .unwrap();
-    assert_eq!(events, [Event::readable(reader_token)]);
+    assert_eq!(
+        events.iter().collect::<Vec<_>>(),
+        [Event::readable(reader_token)]
+    );
 
     // After modifying the stream and sending more data, it should be oneshot.
     poller
@@ -157,7 +172,10 @@ fn edge_triggered() {
         .wait(&mut events, Some(Duration::from_secs(10)))
         .unwrap();
 
-    assert_eq!(events, [Event::readable(reader_token)]);
+    assert_eq!(
+        events.iter().collect::<Vec<_>>(),
+        [Event::readable(reader_token)]
+    );
 }
 
 #[test]
@@ -206,12 +224,15 @@ fn edge_oneshot_triggered() {
     writer.write_all(&data).unwrap();
 
     // A "readable" notification should be delivered.
-    let mut events = Vec::new();
+    let mut events = Events::new();
     poller
         .wait(&mut events, Some(Duration::from_secs(10)))
         .unwrap();
 
-    assert_eq!(events, [Event::readable(reader_token)]);
+    assert_eq!(
+        events.iter().collect::<Vec<_>>(),
+        [Event::readable(reader_token)]
+    );
 
     // If we read some of the data, the notification should not still be available.
     reader.read_exact(&mut [0; 3]).unwrap();
@@ -219,7 +240,7 @@ fn edge_oneshot_triggered() {
     poller
         .wait(&mut events, Some(Duration::from_secs(0)))
         .unwrap();
-    assert_eq!(events, []);
+    assert!(events.is_empty());
 
     // If we modify to re-enable the notification, it should be delivered.
     poller
@@ -233,7 +254,10 @@ fn edge_oneshot_triggered() {
     poller
         .wait(&mut events, Some(Duration::from_secs(0)))
         .unwrap();
-    assert_eq!(events, [Event::readable(reader_token)]);
+    assert_eq!(
+        events.iter().collect::<Vec<_>>(),
+        [Event::readable(reader_token)]
+    );
 }
 
 fn tcp_pair() -> io::Result<(TcpStream, TcpStream)> {

--- a/tests/other_modes.rs
+++ b/tests/other_modes.rs
@@ -39,10 +39,10 @@ fn level_triggered() {
         .wait(&mut events, Some(Duration::from_secs(10)))
         .unwrap();
 
-    assert_eq!(
-        events.iter().collect::<Vec<_>>(),
-        [Event::readable(reader_token)]
-    );
+    assert_eq!(events.len(), 1);
+    assert_eq!(events.iter().next().unwrap().key, reader_token);
+    assert!(events.iter().next().unwrap().readable);
+    assert!(!events.iter().next().unwrap().writable);
 
     // If we read some of the data, the notification should still be available.
     reader.read_exact(&mut [0; 3]).unwrap();
@@ -50,10 +50,11 @@ fn level_triggered() {
     poller
         .wait(&mut events, Some(Duration::from_secs(10)))
         .unwrap();
-    assert_eq!(
-        events.iter().collect::<Vec<_>>(),
-        [Event::readable(reader_token)]
-    );
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events.iter().next().unwrap().key, reader_token);
+    assert!(events.iter().next().unwrap().readable);
+    assert!(!events.iter().next().unwrap().writable);
 
     // If we read the rest of the data, the notification should be gone.
     reader.read_exact(&mut [0; 2]).unwrap();
@@ -77,10 +78,10 @@ fn level_triggered() {
         .wait(&mut events, Some(Duration::from_secs(10)))
         .unwrap();
 
-    assert_eq!(
-        events.iter().collect::<Vec<_>>(),
-        [Event::readable(reader_token)]
-    );
+    assert_eq!(events.len(), 1);
+    assert_eq!(events.iter().next().unwrap().key, reader_token);
+    assert!(events.iter().next().unwrap().readable);
+    assert!(!events.iter().next().unwrap().writable);
 
     // After reading, the notification should vanish.
     reader.read(&mut [0; 5]).unwrap();
@@ -137,10 +138,10 @@ fn edge_triggered() {
         .wait(&mut events, Some(Duration::from_secs(10)))
         .unwrap();
 
-    assert_eq!(
-        events.iter().collect::<Vec<_>>(),
-        [Event::readable(reader_token)]
-    );
+    assert_eq!(events.len(), 1);
+    assert_eq!(events.iter().next().unwrap().key, reader_token);
+    assert!(events.iter().next().unwrap().readable);
+    assert!(!events.iter().next().unwrap().writable);
 
     // If we read some of the data, the notification should not still be available.
     reader.read_exact(&mut [0; 3]).unwrap();
@@ -156,10 +157,11 @@ fn edge_triggered() {
     poller
         .wait(&mut events, Some(Duration::from_secs(10)))
         .unwrap();
-    assert_eq!(
-        events.iter().collect::<Vec<_>>(),
-        [Event::readable(reader_token)]
-    );
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events.iter().next().unwrap().key, reader_token);
+    assert!(events.iter().next().unwrap().readable);
+    assert!(!events.iter().next().unwrap().writable);
 
     // After modifying the stream and sending more data, it should be oneshot.
     poller
@@ -172,10 +174,10 @@ fn edge_triggered() {
         .wait(&mut events, Some(Duration::from_secs(10)))
         .unwrap();
 
-    assert_eq!(
-        events.iter().collect::<Vec<_>>(),
-        [Event::readable(reader_token)]
-    );
+    assert_eq!(events.len(), 1);
+    assert_eq!(events.iter().next().unwrap().key, reader_token);
+    assert!(events.iter().next().unwrap().readable);
+    assert!(!events.iter().next().unwrap().writable);
 }
 
 #[test]
@@ -229,10 +231,9 @@ fn edge_oneshot_triggered() {
         .wait(&mut events, Some(Duration::from_secs(10)))
         .unwrap();
 
-    assert_eq!(
-        events.iter().collect::<Vec<_>>(),
-        [Event::readable(reader_token)]
-    );
+    assert_eq!(events.len(), 1);
+    assert!(events.iter().next().unwrap().readable);
+    assert!(!events.iter().next().unwrap().writable);
 
     // If we read some of the data, the notification should not still be available.
     reader.read_exact(&mut [0; 3]).unwrap();
@@ -254,10 +255,10 @@ fn edge_oneshot_triggered() {
     poller
         .wait(&mut events, Some(Duration::from_secs(0)))
         .unwrap();
-    assert_eq!(
-        events.iter().collect::<Vec<_>>(),
-        [Event::readable(reader_token)]
-    );
+
+    assert_eq!(events.len(), 1);
+    assert!(events.iter().next().unwrap().readable);
+    assert!(!events.iter().next().unwrap().writable);
 }
 
 fn tcp_pair() -> io::Result<(TcpStream, TcpStream)> {

--- a/tests/precision.rs
+++ b/tests/precision.rs
@@ -1,12 +1,12 @@
 use std::io;
 use std::time::{Duration, Instant};
 
-use polling::Poller;
+use polling::{Events, Poller};
 
 #[test]
 fn below_ms() -> io::Result<()> {
     let poller = Poller::new()?;
-    let mut events = Vec::new();
+    let mut events = Events::new();
 
     let dur = Duration::from_micros(100);
     let margin = Duration::from_micros(500);
@@ -42,7 +42,7 @@ fn below_ms() -> io::Result<()> {
 #[test]
 fn above_ms() -> io::Result<()> {
     let poller = Poller::new()?;
-    let mut events = Vec::new();
+    let mut events = Events::new();
 
     let dur = Duration::from_micros(3_100);
     let margin = Duration::from_micros(500);

--- a/tests/timeout.rs
+++ b/tests/timeout.rs
@@ -1,12 +1,12 @@
 use std::io;
 use std::time::{Duration, Instant};
 
-use polling::Poller;
+use polling::{Events, Poller};
 
 #[test]
 fn twice() -> io::Result<()> {
     let poller = Poller::new()?;
-    let mut events = Vec::new();
+    let mut events = Events::new();
 
     for _ in 0..2 {
         let start = Instant::now();
@@ -22,7 +22,7 @@ fn twice() -> io::Result<()> {
 #[test]
 fn non_blocking() -> io::Result<()> {
     let poller = Poller::new()?;
-    let mut events = Vec::new();
+    let mut events = Events::new();
 
     for _ in 0..100 {
         poller.wait(&mut events, Some(Duration::from_secs(0)))?;

--- a/tests/windows_post.rs
+++ b/tests/windows_post.rs
@@ -47,7 +47,10 @@ fn post_multithread() {
             .unwrap();
 
         assert_eq!(events.len(), 1);
-        assert_eq!(events.iter().next(), Some(Event::writable(i)));
+        assert_eq!(events.iter().next().unwrap().key, i);
+        assert!(!events.iter().next().unwrap().readable);
+        assert!(events.iter().next().unwrap().writable);
+        events.clear();
     }
 
     poller

--- a/tests/windows_post.rs
+++ b/tests/windows_post.rs
@@ -3,7 +3,7 @@
 #![cfg(windows)]
 
 use polling::os::iocp::{CompletionPacket, PollerIocpExt};
-use polling::{Event, Poller};
+use polling::{Event, Events, Poller};
 
 use std::sync::Arc;
 use std::thread;
@@ -12,7 +12,7 @@ use std::time::Duration;
 #[test]
 fn post_smoke() {
     let poller = Poller::new().unwrap();
-    let mut events = Vec::new();
+    let mut events = Events::new();
 
     poller
         .post(CompletionPacket::new(Event::readable(1)))
@@ -20,13 +20,13 @@ fn post_smoke() {
     poller.wait(&mut events, None).unwrap();
 
     assert_eq!(events.len(), 1);
-    assert_eq!(events[0], Event::readable(1));
+    assert_eq!(events.iter().next().unwrap(), Event::readable(1));
 }
 
 #[test]
 fn post_multithread() {
     let poller = Arc::new(Poller::new().unwrap());
-    let mut events = Vec::new();
+    let mut events = Events::new();
 
     thread::spawn({
         let poller = Arc::clone(&poller);
@@ -47,7 +47,7 @@ fn post_multithread() {
             .unwrap();
 
         assert_eq!(events.len(), 1);
-        assert_eq!(events.pop(), Some(Event::writable(i)));
+        assert_eq!(events.iter().next(), Some(Event::writable(i)));
     }
 
     poller

--- a/tests/windows_post.rs
+++ b/tests/windows_post.rs
@@ -20,7 +20,10 @@ fn post_smoke() {
     poller.wait(&mut events, None).unwrap();
 
     assert_eq!(events.len(), 1);
-    assert_eq!(events.iter().next().unwrap(), Event::readable(1));
+    assert_eq!(
+        events.iter().next().unwrap().with_no_extra(),
+        Event::readable(1)
+    );
 }
 
 #[test]
@@ -47,9 +50,10 @@ fn post_multithread() {
             .unwrap();
 
         assert_eq!(events.len(), 1);
-        assert_eq!(events.iter().next().unwrap().key, i);
-        assert!(!events.iter().next().unwrap().readable);
-        assert!(events.iter().next().unwrap().writable);
+        assert_eq!(
+            events.iter().next().unwrap().with_no_extra(),
+            Event::writable(i)
+        );
         events.clear();
     }
 

--- a/tests/windows_waitable.rs
+++ b/tests/windows_waitable.rs
@@ -3,7 +3,7 @@
 #![cfg(windows)]
 
 use polling::os::iocp::PollerIocpExt;
-use polling::{Event, PollMode, Poller};
+use polling::{Event, Events, PollMode, Poller};
 
 use windows_sys::Win32::Foundation::CloseHandle;
 use windows_sys::Win32::System::Threading::{CreateEventW, ResetEvent, SetEvent};
@@ -85,7 +85,7 @@ fn smoke() {
             .unwrap();
     }
 
-    let mut events = vec![];
+    let mut events = Events::new();
     poller
         .wait(&mut events, Some(Duration::from_millis(100)))
         .unwrap();
@@ -100,7 +100,8 @@ fn smoke() {
         .unwrap();
 
     assert_eq!(events.len(), 1);
-    assert_eq!(events[0], Event::all(0));
+    assert!(events.iter().next().unwrap().readable);
+    assert!(events.iter().next().unwrap().writable);
 
     // Interest should be cleared.
     events.clear();
@@ -121,7 +122,8 @@ fn smoke() {
         .unwrap();
 
     assert_eq!(events.len(), 1);
-    assert_eq!(events[0], Event::all(0));
+    assert!(events.iter().next().unwrap().readable);
+    assert!(events.iter().next().unwrap().writable);
 
     // If we reset the event, it should not be signaled.
     event.reset().unwrap();

--- a/tests/windows_waitable.rs
+++ b/tests/windows_waitable.rs
@@ -100,8 +100,7 @@ fn smoke() {
         .unwrap();
 
     assert_eq!(events.len(), 1);
-    assert!(events.iter().next().unwrap().readable);
-    assert!(events.iter().next().unwrap().writable);
+    assert_eq!(events.iter().next().unwrap().with_no_extra(), Event::all(0));
 
     // Interest should be cleared.
     events.clear();
@@ -122,8 +121,7 @@ fn smoke() {
         .unwrap();
 
     assert_eq!(events.len(), 1);
-    assert!(events.iter().next().unwrap().readable);
-    assert!(events.iter().next().unwrap().writable);
+    assert_eq!(events.iter().next().unwrap().with_no_extra(), Event::all(0));
 
     // If we reset the event, it should not be signaled.
     event.reset().unwrap();


### PR DESCRIPTION
- Extracts the `Events` struct from `Poller`. This allows us to avoid an intermediate allocation when polling for events in `async-io`.
- Makes `Event` opaque, containing platform-specific data. Closes #66.
- Adds `HUP` and `PRI` tracking to `Event` that is platform-dependent. Closes #112 and [this issue](https://github.com/alacritty/alacritty/pull/6846/files#r1277724556).