### PR TITLE
Add a pipe-based notifier to epoll

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,11 @@ jobs:
           # Note: This cfg is intended to make it easy for polling developers to test
           # the backend that uses poll, and is not a public API.
           RUSTFLAGS: ${{ env.RUSTFLAGS }} --cfg polling_test_poll_backend
+      - run: cargo test
+        env:
+          # Note: This cfg is intended to make it easy for polling developers to test
+          # the backend that uses pipes, and is not a public API.
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} --cfg polling_test_epoll_pipe
         if: startsWith(matrix.os, 'ubuntu')
       - run: cargo hack build --feature-powerset --no-dev-deps
       - name: Add rust-src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
           # Note: This cfg is intended to make it easy for polling developers to test
           # the backend that uses poll, and is not a public API.
           RUSTFLAGS: ${{ env.RUSTFLAGS }} --cfg polling_test_poll_backend
+        if: startsWith(matrix.os, 'ubuntu')
       - run: cargo test
         env:
           # Note: This cfg is intended to make it easy for polling developers to test


### PR DESCRIPTION
In some containers, eventfd is not available as it cannot be implemented securely in some hosts. This commit adds a fallback notifier that uses a pipe instead of eventfd.

Closes #122