### PR TITLE
Remove libc from our dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,7 @@ cfg-if = "1"
 tracing = { version = "0.1.37", default-features = false }
 
 [target.'cfg(any(unix, target_os = "fuchsia", target_os = "vxworks"))'.dependencies]
-libc = "0.2.77"
-rustix = { version = "0.38", features = ["event", "fs", "pipe", "process", "std", "time"], default-features = false }
+rustix = { version = "0.38.8", features = ["event", "fs", "pipe", "process", "std", "time"], default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 concurrent-queue = "2.2.0"
@@ -49,3 +48,6 @@ features = [
 [dev-dependencies]
 easy-parallel = "3.1.0"
 fastrand = "2.0.0"
+
+[target.'cfg(any(unix, target_os = "fuchsia", target_os = "vxworks"))'.dev_dependencies]
+libc = "0.2"

--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -165,7 +165,7 @@ impl Poller {
                     Some(t) => {
                         let mut ts = TS_ZERO;
                         ts.tv_sec = t.as_secs() as _;
-                        ts.tv_nsec = (t.subsec_nanos() as libc::c_long).into();
+                        ts.tv_nsec = (t.subsec_nanos() as std::ffi::c_long).into();
                         ts
                     }
                 },

--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -165,7 +165,7 @@ impl Poller {
                     Some(t) => {
                         let mut ts = TS_ZERO;
                         ts.tv_sec = t.as_secs() as _;
-                        ts.tv_nsec = (t.subsec_nanos() as std::ffi::c_long).into();
+                        ts.tv_nsec = t.subsec_nanos() as _;
                         ts
                     }
                 },

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -128,8 +128,7 @@ impl Poller {
 
         // Check for errors.
         for &ev in &eventlist {
-            // TODO: Once the data field is exposed in rustix, use that.
-            let data = unsafe { (*(&ev as *const kqueue::Event as *const libc::kevent)).data };
+            let data = ev.data();
 
             // Explanation for ignoring EPIPE: https://github.com/tokio-rs/mio/issues/582
             if (ev.flags().contains(kqueue::EventFlags::ERROR))


### PR DESCRIPTION
This means that we only depend on rustix, so all of the system calls are direct. This should make mustang integration trivial.

Closes #113