### PR TITLE
Add support for using CompletionPacket for overlapped I/O

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,6 @@ fastrand = "2.0.0"
 
 [target.'cfg(any(unix, target_os = "fuchsia", target_os = "vxworks"))'.dev_dependencies]
 libc = "0.2"
+
+[target.'cfg(windows)'.dev_dependencies]
+miow = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ features = [
 [dev-dependencies]
 easy-parallel = "3.1.0"
 fastrand = "2.0.0"
+tracing-subscriber = "0.3"
 
 [target.'cfg(any(unix, target_os = "fuchsia", target_os = "vxworks"))'.dev_dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,4 +53,4 @@ fastrand = "2.0.0"
 libc = "0.2"
 
 [target.'cfg(windows)'.dev_dependencies]
-miow = "0.6"
+tempfile = "3.7"

--- a/src/iocp/afd.rs
+++ b/src/iocp/afd.rs
@@ -29,7 +29,7 @@ use windows_sys::Win32::System::WindowsProgramming::{IO_STATUS_BLOCK, OBJECT_ATT
 
 #[derive(Default)]
 #[repr(C)]
-pub(super) struct AfdPollInfo {
+pub(crate) struct AfdPollInfo {
     /// The timeout for this poll.
     timeout: i64,
 
@@ -561,7 +561,7 @@ impl<T> OnceCell<T> {
 pin_project_lite::pin_project! {
     /// An I/O status block paired with some auxillary data.
     #[repr(C)]
-    pub(super) struct IoStatusBlock<T> {
+    pub(crate) struct IoStatusBlock<T> {
         // The I/O status block.
         iosb: UnsafeCell<IO_STATUS_BLOCK>,
 

--- a/src/iocp/mod.rs
+++ b/src/iocp/mod.rs
@@ -32,6 +32,7 @@ use afd::{base_socket, Afd, AfdPollInfo, AfdPollMask, HasAfdInfo};
 use port::{IoCompletionPort, OverlappedEntry};
 
 pub(crate) use afd::IoStatusBlock;
+pub(crate) use port::{Completion, CompletionHandle};
 
 use windows_sys::Win32::Foundation::{
     BOOLEAN, ERROR_INVALID_HANDLE, ERROR_IO_PENDING, STATUS_CANCELLED,

--- a/src/iocp/mod.rs
+++ b/src/iocp/mod.rs
@@ -929,7 +929,7 @@ impl PacketUnwrapped {
                 // The poller was notified.
                 return Ok(FeedEventResult::Notified);
             }
-            PacketInnerProj::Waitable { handle } => {                
+            PacketInnerProj::Waitable { handle } => {
                 let mut handle = lock!(handle.lock());
                 let event = handle.interest;
 

--- a/src/iocp/mod.rs
+++ b/src/iocp/mod.rs
@@ -929,7 +929,7 @@ impl PacketUnwrapped {
                 // The poller was notified.
                 return Ok(FeedEventResult::Notified);
             }
-            PacketInnerProj::Waitable { handle } => {
+            PacketInnerProj::Waitable { handle } => {                
                 let mut handle = lock!(handle.lock());
                 let event = handle.interest;
 

--- a/src/iocp/port.rs
+++ b/src/iocp/port.rs
@@ -27,7 +27,7 @@ use windows_sys::Win32::System::IO::{
 /// # Safety
 ///
 /// This must be a valid completion block.
-pub(super) unsafe trait Completion {
+pub(crate) unsafe trait Completion {
     /// Signal to the completion block that we are about to start an operation.
     fn try_lock(self: Pin<&Self>) -> bool;
 
@@ -40,7 +40,7 @@ pub(super) unsafe trait Completion {
 /// # Safety
 ///
 /// This must be a valid completion block.
-pub(super) unsafe trait CompletionHandle: Deref + Sized {
+pub(crate) unsafe trait CompletionHandle: Deref + Sized {
     /// Type of the completion block.
     type Completion: Completion;
 

--- a/src/os/iocp.rs
+++ b/src/os/iocp.rs
@@ -30,7 +30,7 @@ impl CompletionPacket {
     /// This pointer can be used as an `OVERLAPPED` block in Windows APIs. Calling this function
     /// marks the block as "in use". Trying to call this function again before the operation is
     /// indicated as complete by the poller will result in a panic.
-    pub fn as_ptr(&mut self) -> *mut () {
+    pub fn as_ptr(&self) -> *mut () {
         if !self.0.as_ref().get().try_lock() {
             panic!("completion packet is already in use");
         }

--- a/tests/windows_overlapped.rs
+++ b/tests/windows_overlapped.rs
@@ -1,0 +1,119 @@
+//! Take advantage of overlapped I/O on Windows using CompletionPacket.
+
+#![cfg(windows)]
+
+use polling::os::iocp::CompletionPacket;
+use polling::{Event, Events, Poller};
+
+use std::io;
+use std::os::windows::io::AsRawHandle;
+
+use windows_sys::Win32::{Storage::FileSystem as wfs, System::IO as wio};
+
+#[test]
+fn anonymous_pipe() {
+    // Create an anonymous pipe through miow.
+    let (read, write) = miow::pipe::anonymous(1024).unwrap();
+
+    // Create two completion packets: one for reading, one for writing.
+    let read_packet = CompletionPacket::new(Event::readable(1));
+    let write_packet = CompletionPacket::new(Event::writable(2));
+
+    // Create a poller.
+    let poller = Poller::new().unwrap();
+    let mut events = Events::new();
+
+    // Associate this pipe with the poller.
+    unsafe {
+        let poller_handle = poller.as_raw_handle();
+        if wio::CreateIoCompletionPort(read.as_raw_handle() as _, poller_handle as _, 0, 0) == 0 {
+            panic!(
+                "CreateIoCompletionPort failed: {}",
+                io::Error::last_os_error()
+            );
+        }
+        if wio::CreateIoCompletionPort(write.as_raw_handle() as _, poller_handle as _, 0, 0) == 0 {
+            panic!(
+                "CreateIoCompletionPort failed: {}",
+                io::Error::last_os_error()
+            );
+        }
+    }
+
+    // Repeatedly write to the pipe.
+    let input_text = "Now is the time for all good men to come to the aid of their party";
+    let mut len = input_text.len();
+    let mut bytes_written_or_read = Box::new(0u32);
+    while len > 0 {
+        // Begin the write.
+        unsafe {
+            if wfs::WriteFile(
+                write.as_raw_handle() as _,
+                input_text.as_ptr() as _,
+                len as _,
+                bytes_written_or_read.as_mut() as *mut _,
+                write_packet.as_ptr().cast(),
+            ) == 0
+            {
+                panic!("WriteFile failed: {}", io::Error::last_os_error());
+            }
+        }
+
+        // Wait for the overlapped operation to complete.
+        'waiter: loop {
+            events.clear();
+            poller.wait(&mut events, None).unwrap();
+
+            for event in events.iter() {
+                if event.writable && event.key == 2 {
+                    break 'waiter;
+                }
+            }
+        }
+
+        // Decrement the length by the number of bytes written.
+        len -= *bytes_written_or_read as usize;
+    }
+
+    // Repeatedly read from the pipe.
+    let mut buffer = vec![0u8; 1024];
+    let mut buffer_cursor = &mut *buffer;
+    let mut len = 1024;
+    let mut bytes_received = 0;
+
+    while bytes_received < input_text.len() {
+        // Begin the read.
+        unsafe {
+            if wfs::ReadFile(
+                read.as_raw_handle() as _,
+                buffer_cursor.as_mut_ptr() as _,
+                len as _,
+                bytes_written_or_read.as_mut() as *mut _,
+                read_packet.as_ptr().cast(),
+            ) == 0
+            {
+                panic!("ReadFile failed: {}", io::Error::last_os_error());
+            }
+        }
+
+        // Wait for the overlapped operation to complete.
+        'waiter: loop {
+            events.clear();
+            poller.wait(&mut events, None).unwrap();
+
+            for event in events.iter() {
+                if event.readable && event.key == 1 {
+                    break 'waiter;
+                }
+            }
+        }
+
+        // Increment the cursor and decrement the length by the number of bytes read.
+        buffer_cursor = &mut buffer_cursor[*bytes_written_or_read as usize..];
+        len -= *bytes_written_or_read as usize;
+        bytes_received += *bytes_written_or_read as usize;
+    }
+
+    assert_eq!(bytes_received, input_text.len());
+    assert_eq!(&buffer[..bytes_received], input_text.as_bytes());
+}

--- a/tests/windows_overlapped.rs
+++ b/tests/windows_overlapped.rs
@@ -32,7 +32,7 @@ fn win32_file_io() {
     let file_handle = unsafe {
         let raw_handle = wfs::CreateFileW(
             fname.as_ptr(),
-            wf::GENERIC_WRITE,
+            wf::GENERIC_WRITE | wf::GENERIC_READ,
             0,
             std::ptr::null_mut(),
             wfs::CREATE_ALWAYS,
@@ -65,7 +65,7 @@ fn win32_file_io() {
     let mut len = input_text.len();
     while len > 0 {
         // Begin the write.
-        let ptr = write_packet.as_ptr() as *mut _; 
+        let ptr = write_packet.as_ptr() as *mut _;
         unsafe {
             if wfs::WriteFile(
                 file_handle.as_raw_handle() as _,
@@ -83,7 +83,9 @@ fn win32_file_io() {
         // Wait for the overlapped operation to complete.
         'waiter: loop {
             events.clear();
+            println!("Starting wait...");
             poller.wait(&mut events, None).unwrap();
+            println!("Got events");
 
             for event in events.iter() {
                 if event.writable && event.key == 2 {
@@ -102,7 +104,7 @@ fn win32_file_io() {
     let file_handle = unsafe {
         let raw_handle = wfs::CreateFileW(
             fname.as_ptr(),
-            wf::GENERIC_READ,
+            wf::GENERIC_READ | wf::GENERIC_WRITE,
             0,
             std::ptr::null_mut(),
             wfs::OPEN_EXISTING,


### PR DESCRIPTION
Closes #97 

This allows the packet to be used for overlapped operations, like reading from or writing to files.