### PR TITLE
v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# Version 3.0.0
+
+- Replace `libc` in all backends with the `rustix` crate (#108).
+- Use `tracing` instead of `log` for logging (#119).
+- **Breaking:** Rework the API to use I/O safety. Note that this makes several previously safe functions unsafe. (#123)
+- Add support for the ESP-IDF platform. (#128)
+- **Breaking:** Make `Event` partially opaque, and create a new `Events` struct for holding events. (#133)
+- Add support for running `polling` in Linux containers without `eventfd` available. (#134)
+- Specify the behavior when registered in multiple `Poller`s. (#136)
+- **Breaking:** Use `c_int` from the standard library in `polling::os::kqueue` instead of defining our own. (#143)
+- **Breaking:** Remove the useless `std` feature. (#147)
+
 # Version 2.8.0
 
 - Add functionality for posting events to the IOCP. (#101)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,9 @@
 name = "polling"
 # When publishing a new version:
 # - Update CHANGELOG.md
-# - Create "v2.x.y" git tag
-version = "2.8.0"
-authors = ["Stjepan Glavina <stjepang@gmail.com>"]
+# - Create "v3.x.y" git tag
+version = "3.0.0"
+authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
 edition = "2018"
 rust-version = "1.63"
 description = "Portable interface to epoll, kqueue, event ports, and IOCP"


### PR DESCRIPTION
- Replace `libc` in all backends with the `rustix` crate (#108, #146).
- Use `tracing` instead of `log` for logging (#119).
- **Breaking:** Rework the API to use I/O safety. Note that this makes several previously safe functions unsafe. (#123)
- Add support for the ESP-IDF platform. (#128)
- **Breaking:** Make `Event` partially opaque, and create a new `Events` struct for holding events. (#133)
- Add support for running `polling` in Linux containers without `eventfd` available. (#134)
- Specify the behavior when registered in multiple `Poller`s. (#136)
- **Breaking:** Use `c_int` from the standard library in `polling::os::kqueue` instead of defining our own. (#143)