### PR TITLE
feat: enable construct event constantly

### DIFF
--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -337,7 +337,7 @@ pub struct EventExtra {
 impl EventExtra {
     /// Create an empty version of the data.
     #[inline]
-    pub fn empty() -> EventExtra {
+    pub const fn empty() -> EventExtra {
         EventExtra {
             flags: epoll::EventFlags::empty(),
         }

--- a/src/iocp/afd.rs
+++ b/src/iocp/afd.rs
@@ -81,7 +81,7 @@ impl AfdPollMask {
     pub(crate) const CONNECT_FAIL: AfdPollMask = AfdPollMask(0x100);
 
     /// Creates an empty mask.
-    pub(crate) fn empty() -> AfdPollMask {
+    pub(crate) const fn empty() -> AfdPollMask {
         AfdPollMask(0)
     }
 

--- a/src/iocp/mod.rs
+++ b/src/iocp/mod.rs
@@ -651,7 +651,7 @@ pub struct EventExtra {
 impl EventExtra {
     /// Create a new, empty version of this struct.
     #[inline]
-    pub fn empty() -> EventExtra {
+    pub const fn empty() -> EventExtra {
         EventExtra {
             flags: AfdPollMask::empty(),
         }

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -268,7 +268,7 @@ pub struct EventExtra;
 impl EventExtra {
     /// Create a new, empty version of this struct.
     #[inline]
-    pub fn empty() -> EventExtra {
+    pub const fn empty() -> EventExtra {
         EventExtra
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,7 @@ impl Event {
     /// All kinds of events (readable and writable).
     ///
     /// Equivalent to: `Event { key, readable: true, writable: true }`
-    pub fn all(key: usize) -> Event {
+    pub const fn all(key: usize) -> Event {
         Event {
             key,
             readable: true,
@@ -198,7 +198,7 @@ impl Event {
     /// Only the readable event.
     ///
     /// Equivalent to: `Event { key, readable: true, writable: false }`
-    pub fn readable(key: usize) -> Event {
+    pub const fn readable(key: usize) -> Event {
         Event {
             key,
             readable: true,
@@ -210,7 +210,7 @@ impl Event {
     /// Only the writable event.
     ///
     /// Equivalent to: `Event { key, readable: false, writable: true }`
-    pub fn writable(key: usize) -> Event {
+    pub const fn writable(key: usize) -> Event {
         Event {
             key,
             readable: false,
@@ -222,7 +222,7 @@ impl Event {
     /// No events.
     ///
     /// Equivalent to: `Event { key, readable: false, writable: false }`
-    pub fn none(key: usize) -> Event {
+    pub const fn none(key: usize) -> Event {
         Event {
             key,
             readable: false,

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -398,7 +398,7 @@ pub struct EventExtra {
 impl EventExtra {
     /// Creates an empty set of extra information.
     #[inline]
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         Self {
             flags: PollFlags::empty(),
         }

--- a/src/port.rs
+++ b/src/port.rs
@@ -221,7 +221,7 @@ pub struct EventExtra {
 impl EventExtra {
     /// Create a new, empty version of this struct.
     #[inline]
-    pub fn empty() -> EventExtra {
+    pub const fn empty() -> EventExtra {
         EventExtra {
             flags: PollFlags::empty(),
         }


### PR DESCRIPTION
Maybe https://github.com/smol-rs/polling/pull/133 can prevent this from being possible; since it includes sys details for `Event`.

These `sys` things are one of the main complain on `mio` that I want to get rid of.

Compare with `mio`, it can obtain a `const TOKEN: Token = Token(0)`, while in `polling` we cannot obtain a const interest `Event` like `const INTEREST: Event = Event::readable(1)`. I don't want to know about the `sys` things.

cc @notgull 