### PR TITLE
Use std::os::raw::c_int and remove our own type alias

### DIFF
--- a/src/os/kqueue.rs
+++ b/src/os/kqueue.rs
@@ -135,11 +135,7 @@ impl<T: Filter + ?Sized> Filter for &T {}
 /// No matter what `PollMode` is specified, this filter will always be
 /// oneshot-only.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Signal(pub c_int);
-
-/// Alias for `libc::c_int`.
-#[allow(non_camel_case_types)]
-pub type c_int = i32;
+pub struct Signal(pub std::os::raw::c_int);
 
 unsafe impl FilterSealed for Signal {
     #[inline(always)]


### PR DESCRIPTION
They are always i32 in macos/bsd, but it is better to be clear that they are the same as std c_int.