### PR TITLE
Remove the std default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,6 @@ exclude = ["/.*"]
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 
-[features]
-default = ["std"]
-std = []
-
 [dependencies]
 cfg-if = "1"
 tracing = { version = "0.1.37", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,8 +53,6 @@
 //! # std::io::Result::Ok(())
 //! ```
 
-#![cfg(feature = "std")]
-#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![allow(clippy::useless_conversion, clippy::unnecessary_cast, unused_unsafe)]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
Added in 272bb11eafd22c063bc2e7825070c21443a8fc78 for reasons that are unclear to me. It serves no purpose aside from disabling the API of the entire crate, so it's best to remove it.