### PR TITLE
haiku support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Check selected Tier 3 targets
         if: startsWith(matrix.rust, 'nightly') && matrix.os == 'ubuntu-latest'
         run: cargo check -Z build-std --target=riscv32imc-esp-espidf
+      - name: Check haiku
+        if: startsWith(matrix.rust, 'nightly') && matrix.os == 'ubuntu-latest'
+        run: cargo check -Z build-std --target x86_64-unknown-haiku
 
   cross:
     runs-on: ${{ matrix.os }}

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -446,10 +446,14 @@ mod notify {
     use rustix::event::PollFlags;
     use rustix::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
     use rustix::fs::{fcntl_getfl, fcntl_setfl, OFlags};
-    use rustix::io::{fcntl_getfd, fcntl_setfd, read, write, FdFlags};
-    use rustix::pipe::{pipe,PipeFlags};
+    #[cfg(target_os = "haiku")]
+    use rustix::io::{fcntl_getfd, fcntl_setfd, FdFlags};
+    use rustix::io::{read, write};
+    #[cfg(target_os = "haiku")]
+    use rustix::pipe::pipe;
     #[cfg(not(target_os = "haiku"))]
     use rustix::pipe::pipe_with;
+    use rustix::pipe::PipeFlags;
 
     /// A notification pipe.
     ///

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -439,7 +439,7 @@ fn cvt_mode_as_remove(mode: PollMode) -> io::Result<bool> {
     }
 }
 
-#[cfg(not(target_os = "espidf"))]
+#[cfg(not(any(target_os = "espidf", target_os = "haiku")))]
 mod notify {
     use std::io;
 
@@ -474,6 +474,86 @@ mod notify {
                 fcntl_setfd(&write_pipe, fcntl_getfd(&write_pipe)? | FdFlags::CLOEXEC)?;
                 io::Result::Ok((read_pipe, write_pipe))
             })?;
+
+            // Put the reading side into non-blocking mode.
+            fcntl_setfl(&read_pipe, fcntl_getfl(&read_pipe)? | OFlags::NONBLOCK)?;
+
+            Ok(Self {
+                read_pipe,
+                write_pipe,
+            })
+        }
+
+        /// Provides the file handle of the read half of the notify pipe that needs to be registered by the `Poller`.
+        pub(super) fn fd(&self) -> BorrowedFd<'_> {
+            self.read_pipe.as_fd()
+        }
+
+        /// Provides the poll flags to be used when registering the read half of the botify pipe with the `Poller`.
+        pub(super) fn poll_flags(&self) -> PollFlags {
+            PollFlags::RDNORM
+        }
+
+        /// Notifies the `Poller` instance via the write half of the notify pipe.
+        pub(super) fn notify(&self) -> Result<(), io::Error> {
+            write(&self.write_pipe, &[0; 1])?;
+
+            Ok(())
+        }
+
+        /// Pops a notification (if any) from the pipe.
+        pub(super) fn pop_notification(&self) -> Result<(), io::Error> {
+            read(&self.read_pipe, &mut [0; 1])?;
+
+            Ok(())
+        }
+
+        /// Pops all notifications from the pipe.
+        pub(super) fn pop_all_notifications(&self) -> Result<(), io::Error> {
+            while read(&self.read_pipe, &mut [0; 64]).is_ok() {}
+
+            Ok(())
+        }
+
+        /// Whether this raw file descriptor is associated with this notifier.
+        pub(super) fn has_fd(&self, fd: RawFd) -> bool {
+            self.read_pipe.as_raw_fd() == fd || self.write_pipe.as_raw_fd() == fd
+        }
+    }
+}
+
+#[cfg(target_os = "haiku")]
+mod notify {
+    use std::io;
+
+    use rustix::event::PollFlags;
+    use rustix::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
+    use rustix::fs::{fcntl_getfl, fcntl_setfl, OFlags};
+    use rustix::io::{fcntl_getfd, fcntl_setfd, read, write, FdFlags};
+    use rustix::pipe::{pipe};
+
+    /// A notification pipe.
+    ///
+    /// This implementation uses a pipe to send notifications.
+    #[derive(Debug)]
+    pub(super) struct Notify {
+        /// The file descriptor of the read half of the notify pipe. This is also stored as the first
+        /// file descriptor in `fds.poll_fds`.
+        read_pipe: OwnedFd,
+        /// The file descriptor of the write half of the notify pipe.
+        ///
+        /// Data is written to this to wake up the current instance of `Poller::wait`, which can occur when the
+        /// user notifies it (in which case `Poller::notified` would have been set) or when an operation needs
+        /// to occur (in which case `Poller::waiting_operations` would have been incremented).
+        write_pipe: OwnedFd,
+    }
+
+    impl Notify {
+        /// Creates a new notification pipe.
+        pub(super) fn new() -> io::Result<Self> {
+            let (read_pipe, write_pipe) = pipe()?;
+            fcntl_setfd(&read_pipe, fcntl_getfd(&read_pipe)? | FdFlags::CLOEXEC)?;
+            fcntl_setfd(&write_pipe, fcntl_getfd(&write_pipe)? | FdFlags::CLOEXEC)?;
 
             // Put the reading side into non-blocking mode.
             fcntl_setfl(&read_pipe, fcntl_getfl(&read_pipe)? | OFlags::NONBLOCK)?;

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -569,7 +569,7 @@ mod notify {
             self.read_pipe.as_fd()
         }
 
-        /// Provides the poll flags to be used when registering the read half of the botify pipe with the `Poller`.
+        /// Provides the poll flags to be used when registering the read half of the notify pipe with the `Poller`.
         pub(super) fn poll_flags(&self) -> PollFlags {
             PollFlags::RDNORM
         }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -530,7 +530,7 @@ mod notify {
     use rustix::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
     use rustix::fs::{fcntl_getfl, fcntl_setfl, OFlags};
     use rustix::io::{fcntl_getfd, fcntl_setfd, read, write, FdFlags};
-    use rustix::pipe::{pipe};
+    use rustix::pipe::pipe;
 
     /// A notification pipe.
     ///


### PR DESCRIPTION
hello!

this changeset fixes an error that occurs when trying to compile on haiku that would typically show up like so:

```
...
...
error[E0432]: unresolved import `rustix::pipe::pipe_with`
   --> src/poll.rs:450:30
    |
450 |     use rustix::pipe::{pipe, pipe_with, PipeFlags};
    |                              ^^^^^^^^^ no `pipe_with` in `pipe`

For more information about this error, try `rustc --explain E0432`.
warning: `polling` (lib) generated 1 warning
error: could not compile `polling` due to previous error; 1 warning emitted
```

haiku doesn't offer pipe2() which appears to be the problem. this changeset updates the haiku case to prefer pipe() instead. an example test run with patch applied is shown below:

```
> uname -a
Haiku shredder 1 hrev57294 Sep 24 2023 07:34:59 x86_64 x86_64 Haiku

> cargo build && cargo test
   Compiling libc v0.2.148
   Compiling rustix v0.38.14
   Compiling bitflags v2.4.0
   Compiling tracing-core v0.1.31
   Compiling pin-project-lite v0.2.13
   Compiling cfg-if v1.0.0
   Compiling tracing v0.1.37
   Compiling errno v0.3.3
   Compiling polling v3.1.0 (/boot/home/src/git/rust-libs/polling)
    Finished dev [unoptimized + debuginfo] target(s) in 12.35s
   Compiling easy-parallel v3.3.1
   Compiling fastrand v2.0.1
   Compiling polling v3.1.0 (/boot/home/src/git/rust-libs/polling)
    Finished test [unoptimized + debuginfo] target(s) in 19.93s
     Running unittests src/lib.rs (target/debug/deps/polling-0b8e69d1ee132cd7)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/concurrent_modification.rs (target/debug/deps/concurrent_modification-d64066843130bb94)

running 2 tests
test concurrent_add ... ok
test concurrent_modify ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.11s

     Running tests/io.rs (target/debug/deps/io-8d88ea176e7058d2)

running 2 tests
test insert_twice ... ok
test basic_io ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/many_connections.rs (target/debug/deps/many_connections-1718dd2743f7b3ba)

running 1 test
test many_connections ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

     Running tests/multiple_pollers.rs (target/debug/deps/multiple_pollers-00e7f36939f0061d)

running 3 tests
test edge_triggered ... ok
test level_triggered ... ok
test oneshot_triggered ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 6.70s

     Running tests/notify.rs (target/debug/deps/notify-0524de0c61bbacd2)

running 2 tests
test simple ... ok
test concurrent ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/other_modes.rs (target/debug/deps/other_modes-0a6db0bb1c2c5be2)

running 3 tests
test edge_triggered ... ok
test level_triggered ... ok
test edge_oneshot_triggered ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/precision.rs (target/debug/deps/precision-69006f184ddddf9e)

running 2 tests
test below_ms ... ok
test above_ms ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 9.84s

     Running tests/timeout.rs (target/debug/deps/timeout-2ebbe2c5ba4fc740)

running 2 tests
test non_blocking ... ok
test twice ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.83s

     Running tests/windows_post.rs (target/debug/deps/windows_post-ad5e81d62a192ef5)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/windows_waitable.rs (target/debug/deps/windows_waitable-898e88b8f9e88518)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests polling

running 17 tests
test src/lib.rs - Events::clear (line 792) - compile ... ok
test src/lib.rs - (line 20) - compile ... ok
test src/lib.rs - Events::is_empty (line 830) ... ok
test src/lib.rs - Events::capacity (line 845) ... ok
test src/lib.rs - Events::len (line 815) ... ok
test src/lib.rs - Events::iter (line 771) ... ok
test src/lib.rs - Poller::add (line 434) - compile ... ok
test src/lib.rs - Events::with_capacity (line 750) ... ok
test src/lib.rs - Poller::modify (line 505) - compile ... ok
test src/lib.rs - Events::new (line 729) ... ok
test src/lib.rs - Poller::modify (line 517) - compile ... ok
test src/lib.rs - Poller::modify (line 530) - compile ... ok
test src/lib.rs - Poller::modify (line 543) - compile ... ok
test src/lib.rs - Poller::delete (line 594) ... ok
test src/lib.rs - Poller::new (line 364) ... ok
test src/lib.rs - Poller::notify (line 678) ... ok
test src/lib.rs - Poller::wait (line 631) ... ok

test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.81s
```