### PR TITLE
v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 3.2.0
+
+- The `kqueue` backend previously allowed the following operations that other backends forbid. Now these operations result in an error: (#153)
+  - Inserting a source that was already inserted.
+  - Modifying/deleting a source that was not already inserted.
+- Add support for Haiku OS. (#154)
+
 # Version 3.1.0
 
 - Add an `Event::new()` constructor to simplify creating `Event`s. (#149)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "polling"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v3.x.y" git tag
-version = "3.1.0"
+version = "3.2.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
 edition = "2018"
 rust-version = "1.63"


### PR DESCRIPTION
- The `kqueue` backend previously allowed the following operations that other backends forbid. Now these operations result in an error: (#153)
  - Inserting a source that was already inserted.
  - Modifying/deleting a source that was not already inserted.
- Add support for Haiku OS. (#154)