### PR TITLE
Migrate to Rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "polling"
 # - Create "v3.x.y" git tag
 version = "3.2.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.63"
 description = "Portable interface to epoll, kqueue, event ports, and IOCP"
 license = "Apache-2.0 OR MIT"

--- a/src/iocp/mod.rs
+++ b/src/iocp/mod.rs
@@ -46,7 +46,6 @@ use pin_project_lite::pin_project;
 
 use std::cell::UnsafeCell;
 use std::collections::hash_map::{Entry, HashMap};
-use std::convert::TryFrom;
 use std::ffi::c_void;
 use std::fmt;
 use std::io;


### PR DESCRIPTION
Our MSRV (1.63) is higher than 1.56 that Rust 2021 was stabilized.