### PR TITLE
Fix wrong link in docs of Poller::wait()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -609,8 +609,8 @@ impl Poller {
 
     /// Waits for at least one I/O event and returns the number of new events.
     ///
-    /// New events will be appended to `events`. If necessary, make sure to clear the [`Vec`]
-    /// before calling [`wait()`][`Poller::wait()`]!
+    /// New events will be appended to `events`. If necessary, make sure to clear the
+    /// [`Events`][Events::clear()] before calling [`wait()`][`Poller::wait()`]!
     ///
     /// This method will return with no new events if a notification is delivered by the
     /// [`notify()`] method, or the timeout is reached. Sometimes it may even return with no events


### PR DESCRIPTION
Once upon a time, this got a Vec as an argument, but that was replaced with the Events struct. Thus, this should link to Events and not Vec.

Screenshot of result:  
![foo](https://github.com/smol-rs/polling/assets/89482/f333632b-2fde-467f-90a0-281decb08aaa)
