### PR TITLE
Handle interrupts while polling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,7 @@ features = [
 [dev-dependencies]
 easy-parallel = "3.1.0"
 fastrand = "2.0.0"
+
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"
+signal-hook = "0.3.17"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -646,7 +646,7 @@ impl Poller {
     /// poller.delete(&socket)?;
     /// # std::io::Result::Ok(())
     /// ```
-    pub fn wait(&self, events: &mut Events, mut timeout: Option<Duration>) -> io::Result<usize> {
+    pub fn wait(&self, events: &mut Events, timeout: Option<Duration>) -> io::Result<usize> {
         let span = tracing::trace_span!("Poller::wait", ?timeout);
         let _enter = span.enter();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -656,6 +656,7 @@ impl Poller {
                 if let Err(e) = self.poller.wait(&mut events.events, timeout) {
                     // If the wait was interrupted by a signal, clear events and try again.
                     if e.kind() == io::ErrorKind::Interrupted {
+                        events.clear();
                         continue;
                     } else {
                         return Err(e);

--- a/tests/concurrent_modification.rs
+++ b/tests/concurrent_modification.rs
@@ -76,6 +76,53 @@ fn concurrent_modify() -> io::Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+#[test]
+fn concurrent_interruption() -> io::Result<()> {
+    struct MakeItSend<T>(T);
+    unsafe impl<T> Send for MakeItSend<T> {}
+
+    let (reader, _writer) = tcp_pair()?;
+    let poller = Poller::new()?;
+    unsafe {
+        poller.add(&reader, Event::none(0))?;
+    }
+
+    let mut events = Events::new();
+    let events_borrow = &mut events;
+    let (sender, receiver) = std::sync::mpsc::channel();
+
+    Parallel::new()
+        .add(move || {
+            // Register a signal handler so that the syscall is actually interrupted. A signal that
+            // is ignored by default does not cause an interrupted syscall.
+            signal_hook::flag::register(signal_hook::consts::signal::SIGURG, Default::default())?;
+
+            // Signal to the other thread how to send a signal to us
+            sender
+                .send(MakeItSend(unsafe { libc::pthread_self() }))
+                .unwrap();
+
+            poller.wait(events_borrow, Some(Duration::from_secs(1)))?;
+            Ok(())
+        })
+        .add(move || {
+            let MakeItSend(target_thread) = receiver.recv().unwrap();
+            thread::sleep(Duration::from_millis(100));
+            assert_eq!(0, unsafe {
+                libc::pthread_kill(target_thread, libc::SIGURG)
+            });
+            Ok(())
+        })
+        .run()
+        .into_iter()
+        .collect::<io::Result<()>>()?;
+
+    assert_eq!(events.len(), 0);
+
+    Ok(())
+}
+
 fn tcp_pair() -> io::Result<(TcpStream, TcpStream)> {
     let listener = TcpListener::bind("127.0.0.1:0")?;
     let a = TcpStream::connect(listener.local_addr()?)?;


### PR DESCRIPTION
Previous, `Poller::wait` would bubble signal interruption error to the user. However, this may be unexpected for simple use cases. Thus, this commit makes it so, if `ErrorKind::Interrupted` is received by the underlying `wait()` call, it clears the events and tries to wait again.

This also adds a test for this interruption written by @psychon.

Closes #162 