### PR TITLE
Add add_outlives method to Poller

### DIFF
--- a/src/os.rs
+++ b/src/os.rs
@@ -22,5 +22,5 @@ mod __private {
     #[doc(hidden)]
     pub trait PollerSealed {}
 
-    impl PollerSealed for crate::Poller {}
+    impl PollerSealed for crate::Poller<'_> {}
 }


### PR DESCRIPTION
resolves #161 

The previous implementation only implemented unsafe methods for registering file descriptors with `Poller`. This implements an `add_outlives` method that can guarantee safety by accepting a reference to an `AsSource` which outlives the `Poller`. Since file descriptors are guaranteed to be valid through the lifetime of the `Poller`, there is no need to ever delete to maintain soundness.

Please advise if I should change anything.
