### PR TITLE
Fix CI failures

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,7 @@ env:
 freebsd_task:
   name: test ($TARGET)
   freebsd_instance:
-    image_family: freebsd-12-4
+    image_family: freebsd-13-2
   matrix:
     - env:
         TARGET: x86_64-unknown-freebsd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,21 +127,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        # When updating this, the reminder to update the minimum supported
-        # Rust version in Cargo.toml.
-        rust: ['1.63']
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust
-        # --no-self-update is necessary because the windows environment cannot self-update rustup.exe.
-        run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
-      - run: cargo build
-      - name: Install Other Targets
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - run: cargo hack build --no-dev-deps --rust-version
+      - run: cargo hack build --no-dev-deps --rust-version --target x86_64-unknown-freebsd
         if: startsWith(matrix.os, 'ubuntu')
-        run: rustup target add x86_64-unknown-freebsd x86_64-unknown-netbsd
-      - run: cargo build --target x86_64-unknown-freebsd
-        if: startsWith(matrix.os, 'ubuntu')
-      - run: cargo build --target x86_64-unknown-netbsd
+      - run: cargo hack build --no-dev-deps --rust-version --target x86_64-unknown-netbsd
         if: startsWith(matrix.os, 'ubuntu')
 
   clippy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,10 @@ jobs:
       - name: Add rust-src
         if: startsWith(matrix.rust, 'nightly')
         run: rustup component add rust-src
-      - name: Check selected Tier 3 targets
-        if: startsWith(matrix.rust, 'nightly') && matrix.os == 'ubuntu-latest'
-        run: cargo check -Z build-std --target=riscv32imc-esp-espidf
+      # TODO: broken due to https://github.com/rust-lang/rust/pull/119026.
+      # - name: Check selected Tier 3 targets
+      #   if: startsWith(matrix.rust, 'nightly') && matrix.os == 'ubuntu-latest'
+      #   run: cargo check -Z build-std --target=riscv32imc-esp-espidf
       - name: Check haiku
         if: startsWith(matrix.rust, 'nightly') && matrix.os == 'ubuntu-latest'
         run: cargo check -Z build-std --target x86_64-unknown-haiku

--- a/src/iocp/mod.rs
+++ b/src/iocp/mod.rs
@@ -1152,7 +1152,7 @@ enum WaitableStatus {
     Idle,
 
     /// We are waiting on this handle to become signaled.
-    Waiting(WaitHandle),
+    Waiting(#[allow(dead_code)] WaitHandle),
 
     /// This handle has been cancelled.
     Cancelled,


### PR DESCRIPTION
- Ignore dead_code warning for tuple struct 
  This lint does not take into account destructors. https://github.com/rust-lang/rust/issues/119645
  https://github.com/smol-rs/polling/actions/runs/7435513674/job/20230928568
- Temporarily disable riscv32imc-esp-espidf build
  This target is currently broken due to https://github.com/rust-lang/rust/pull/119026.
  https://github.com/smol-rs/polling/actions/runs/7435513674/job/20230928224
- Update FreeBSD image to 13.2 to fix CI failure due to FreeBSD 12.4 EoL
- Use cargo-hack's --rust-version flag for msrv check
  This respects rust-version field in Cargo.toml, so it removes the need to manage MSRV in both the CI file and Cargo.toml.
