### PR TITLE
v3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 3.3.2
+
+- When AFD fails to initialize, the resulting error now references
+  the underlying system error. (#174)
+
 # Version 3.3.1
 
 - Bump `windows-sys` to v0.52.0. (#169)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "polling"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v3.x.y" git tag
-version = "3.3.1"
+version = "3.3.2"
 authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
- When AFD fails to initialize, the resulting error now references
  the underlying system error. (#174)
