### PR TITLE
feat : add the ability to identify if tcp connection has failed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ features = [
 [dev-dependencies]
 easy-parallel = "3.1.0"
 fastrand = "2.0.0"
+socket2 = "0.5.5"
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = "0.2"

--- a/examples/tcp_client.rs
+++ b/examples/tcp_client.rs
@@ -11,30 +11,23 @@ fn main() -> io::Result<()> {
     }
     let addr = net::SocketAddr::new(net::Ipv4Addr::LOCALHOST.into(), 8080);
     socket.set_nonblocking(true)?;
-    let res = socket.connect(&addr.into());
+    let _ = socket.connect(&addr.into());
 
     let mut events = polling::Events::new();
-    // while let Err(ref e) = res {
-        // if e.kind() != io::ErrorKind::WouldBlock {
-        //     return Err(io::Error::new(e.kind(), e.to_string()));
-        // }
 
-        events.clear();
-        poller.wait(&mut events, None)?;
+    events.clear();
+    poller.wait(&mut events, None)?;
 
-        let event = events.iter().next();
-        if event.is_none() {
-            println!("no event");
-            // break;
-        }
+    let event = events.iter().next();
+    let Some(event) = event else {
+        println!("no event");
+        return Ok(());
+    };
 
-        let event = event.unwrap();
-        println!("event: {:?}", event);
-        if event.is_connect_failed() {
-            println!("connect failed");
-            // break;
-        }
-    // }
+    println!("event: {:?}", event);
+    if event.is_connect_failed() {
+        println!("connect failed");
+    }
 
     Ok(())
 }

--- a/examples/tcp_client.rs
+++ b/examples/tcp_client.rs
@@ -2,7 +2,6 @@ use std::{io, net};
 
 use polling::Event;
 use socket2::Type;
-use tracing::event;
 
 fn main() -> io::Result<()> {
     let socket = socket2::Socket::new(socket2::Domain::IPV4, Type::STREAM, None)?;
@@ -12,13 +11,13 @@ fn main() -> io::Result<()> {
     }
     let addr = net::SocketAddr::new(net::Ipv4Addr::LOCALHOST.into(), 8080);
     socket.set_nonblocking(true)?;
-    let mut res = socket.connect(&addr.into());
+    let res = socket.connect(&addr.into());
 
     let mut events = polling::Events::new();
-    while let Err(ref e) = res {
-        if e.kind() != io::ErrorKind::WouldBlock {
-            return Err(io::Error::new(e.kind(), e.to_string()));
-        }
+    // while let Err(ref e) = res {
+        // if e.kind() != io::ErrorKind::WouldBlock {
+        //     return Err(io::Error::new(e.kind(), e.to_string()));
+        // }
 
         events.clear();
         poller.wait(&mut events, None)?;
@@ -26,16 +25,16 @@ fn main() -> io::Result<()> {
         let event = events.iter().next();
         if event.is_none() {
             println!("no event");
-            break;
+            // break;
         }
 
         let event = event.unwrap();
         println!("event: {:?}", event);
         if event.is_connect_failed() {
             println!("connect failed");
-            break;
+            // break;
         }
-    }
+    // }
 
     Ok(())
 }

--- a/examples/tcp_client.rs
+++ b/examples/tcp_client.rs
@@ -1,0 +1,41 @@
+use std::{io, net};
+
+use polling::Event;
+use socket2::Type;
+use tracing::event;
+
+fn main() -> io::Result<()> {
+    let socket = socket2::Socket::new(socket2::Domain::IPV4, Type::STREAM, None)?;
+    let poller = polling::Poller::new()?;
+    unsafe {
+        poller.add(&socket, Event::new(0, true, true))?;
+    }
+    let addr = net::SocketAddr::new(net::Ipv4Addr::LOCALHOST.into(), 8080);
+    socket.set_nonblocking(true)?;
+    let mut res = socket.connect(&addr.into());
+
+    let mut events = polling::Events::new();
+    while let Err(ref e) = res {
+        if e.kind() != io::ErrorKind::WouldBlock {
+            return Err(io::Error::new(e.kind(), e.to_string()));
+        }
+
+        events.clear();
+        poller.wait(&mut events, None)?;
+
+        let event = events.iter().next();
+        if event.is_none() {
+            println!("no event");
+            break;
+        }
+
+        let event = event.unwrap();
+        println!("event: {:?}", event);
+        if event.is_connect_failed() {
+            println!("connect failed");
+            break;
+        }
+    }
+
+    Ok(())
+}

--- a/examples/tcp_client.rs
+++ b/examples/tcp_client.rs
@@ -19,9 +19,12 @@ fn main() -> io::Result<()> {
     poller.wait(&mut events, None)?;
 
     let event = events.iter().next();
-    let Some(event) = event else {
-        println!("no event");
-        return Ok(());
+    let event = match event {
+        Some(event) => event,
+        None => {
+            println!("no event");
+            return Ok(());
+        },
     };
 
     println!("event: {:?}", event);

--- a/examples/tcp_client.rs
+++ b/examples/tcp_client.rs
@@ -28,10 +28,7 @@ fn main() -> io::Result<()> {
     };
 
     println!("event: {:?}", event);
-    if event
-        .is_connect_failed()
-        .expect("is connect failed does not support on this platform")
-    {
+    if event.is_connect_failed().unwrap_or_default() {
         println!("connect failed");
     }
 

--- a/examples/tcp_client.rs
+++ b/examples/tcp_client.rs
@@ -25,7 +25,10 @@ fn main() -> io::Result<()> {
     };
 
     println!("event: {:?}", event);
-    if event.is_connect_failed() {
+    if event
+        .is_connect_failed()
+        .expect("is connect failed does not support on this platform")
+    {
         println!("connect failed");
     }
 

--- a/examples/tcp_client.rs
+++ b/examples/tcp_client.rs
@@ -24,7 +24,7 @@ fn main() -> io::Result<()> {
         None => {
             println!("no event");
             return Ok(());
-        },
+        }
     };
 
     println!("event: {:?}", event);

--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -368,7 +368,7 @@ impl EventExtra {
 
     #[inline]
     pub fn is_connect_failed(&self) -> bool {
-        self.flags.contains(epoll::EventFlags::ERR) && self.flags.contains(epoll::EventFlags::HUP)
+        self.flags.contains(epoll::EventFlags::ERR) || self.flags.contains(epoll::EventFlags::HUP)
     }
 }
 

--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -365,6 +365,11 @@ impl EventExtra {
     pub fn is_pri(&self) -> bool {
         self.flags.contains(epoll::EventFlags::PRI)
     }
+
+    #[inline]
+    pub fn is_connect_failed(&self) -> bool {
+        self.flags.contains(epoll::EventFlags::ERR) && self.flags.contains(epoll::EventFlags::HUP)
+    }
 }
 
 /// The notifier for Linux.

--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -368,7 +368,10 @@ impl EventExtra {
 
     #[inline]
     pub fn is_connect_failed(&self) -> bool {
-        Some(self.flags.contains(epoll::EventFlags::ERR) || self.flags.contains(epoll::EventFlags::HUP))
+        Some(
+            self.flags.contains(epoll::EventFlags::ERR)
+                || self.flags.contains(epoll::EventFlags::HUP),
+        )
     }
 }
 

--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -368,7 +368,7 @@ impl EventExtra {
 
     #[inline]
     pub fn is_connect_failed(&self) -> bool {
-        self.flags.contains(epoll::EventFlags::ERR) || self.flags.contains(epoll::EventFlags::HUP)
+        Some(self.flags.contains(epoll::EventFlags::ERR) || self.flags.contains(epoll::EventFlags::HUP))
     }
 }
 

--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -367,7 +367,7 @@ impl EventExtra {
     }
 
     #[inline]
-    pub fn is_connect_failed(&self) -> bool {
+    pub fn is_connect_failed(&self) -> Option<bool> {
         Some(
             self.flags.contains(epoll::EventFlags::ERR)
                 || self.flags.contains(epoll::EventFlags::HUP),

--- a/src/iocp/mod.rs
+++ b/src/iocp/mod.rs
@@ -684,8 +684,8 @@ impl EventExtra {
 
     /// Check if TCP connect failed.
     #[inline]
-    pub fn is_connect_failed(&self) -> bool {
-        self.flags.intersects(AfdPollMask::CONNECT_FAIL)
+    pub fn is_connect_failed(&self) -> Option<bool> {
+        Some(self.flags.intersects(AfdPollMask::CONNECT_FAIL))
     }
 }
 

--- a/src/iocp/mod.rs
+++ b/src/iocp/mod.rs
@@ -681,6 +681,12 @@ impl EventExtra {
     pub fn set_pri(&mut self, active: bool) {
         self.flags.set(AfdPollMask::RECEIVE_EXPEDITED, active);
     }
+
+    /// Check if TCP connect failed.
+    #[inline]
+    pub fn is_connect_failed(&self) -> bool {
+        self.flags.intersects(AfdPollMask::CONNECT_FAIL)
+    }
 }
 
 /// A packet used to wake up the poller with an event.

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -373,8 +373,8 @@ impl EventExtra {
     }
 
     #[inline]
-    pub fn is_connect_failed(&self) -> bool {
-        unimplemented!("is connect failed is not supported on kqueue");
+    pub fn is_connect_failed(&self) -> Option<bool> {
+        None
     }
 }
 

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -376,7 +376,6 @@ impl EventExtra {
     pub fn is_connect_failed(&self) -> bool {
         unimplemented!("is connect failed is not supported on kqueue");
     }
-
 }
 
 pub(crate) fn mode_to_flags(mode: PollMode) -> kqueue::EventFlags {

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -371,6 +371,12 @@ impl EventExtra {
     pub fn is_pri(&self) -> bool {
         false
     }
+
+    #[inline]
+    pub fn is_connect_failed(&self) -> bool {
+        unimplemented!("is connect failed is not supported on kqueue");
+    }
+
 }
 
 pub(crate) fn mode_to_flags(mode: PollMode) -> kqueue::EventFlags {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,7 +334,10 @@ impl Event {
 
     /// Tell if this event is the result of a connect failure.
     /// 
-    /// This indicates that a non-blocking connect operation has failed. 
+    /// This indicates a tcp connection has failed, it corresponds to the `EPOLLERR` along with `EPOLLHUP` event in linux
+    /// and `CONNECT_FAILED` event in windows IOCP.
+    /// 
+
     #[inline]
     pub fn is_connect_failed(&self) -> bool {
         self.extra.is_connect_failed()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,7 +373,7 @@ impl Event {
     ///     println!("event: {:?}", event);
     ///     if event
     ///         .is_connect_failed()
-    ///         .expect("is connect failed does not support on this platform")
+    ///         .unwrap_or_default()
     ///     {
     ///         println!("connect failed");
     ///     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,6 +332,14 @@ impl Event {
         self.extra.is_pri()
     }
 
+    /// Tell if this event is the result of a connect failure.
+    /// 
+    /// This indicates that a non-blocking connect operation has failed. 
+    #[inline]
+    pub fn is_connect_failed(&self) -> bool {
+        self.extra.is_connect_failed()
+    }
+
     /// Remove any extra information from this event.
     #[inline]
     pub fn clear_extra(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,10 +333,10 @@ impl Event {
     }
 
     /// Tell if this event is the result of a connect failure.
-    /// 
+    ///
     /// This indicates a tcp connection has failed, it corresponds to the `EPOLLERR` along with `EPOLLHUP` event in linux
     /// and `CONNECT_FAILED` event in windows IOCP.
-    /// 
+    ///
 
     #[inline]
     pub fn is_connect_failed(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,9 +361,13 @@ impl Event {
     ///     poller.wait(&mut events, None)?;
     ///
     ///     let event = events.iter().next();
-    ///     let Some(event) = event else {
-    ///         println!("no event");
-    ///         return Ok(());
+    /// 
+    ///     let event = match event {
+    ///         Some(event) => event,
+    ///         None => {
+    ///             println!("no event");
+    ///             return Ok(());
+    ///         },
     ///     };
     ///
     ///     println!("event: {:?}", event);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,14 +332,58 @@ impl Event {
         self.extra.is_pri()
     }
 
-    /// Tell if this event is the result of a connect failure.
+    /// Tells if this event is the result of a connection failure.
     ///
-    /// This indicates a tcp connection has failed, it corresponds to the `EPOLLERR` along with `EPOLLHUP` event in linux
-    /// and `CONNECT_FAILED` event in windows IOCP.
+    /// This function checks if a TCP connection has failed. It corresponds to the `EPOLLERR`  or `EPOLLHUP` event in Linux
+    /// and `CONNECT_FAILED` event in Windows IOCP.
     ///
-
+    /// # Examples
+    ///
+    /// ```
+    /// use std::{io, net};
+    /// // Assuming polling and socket2 are included as dependencies in Cargo.toml
+    /// use polling::Event;
+    /// use socket2::Type;
+    ///
+    /// fn main() -> io::Result<()> {
+    ///     let socket = socket2::Socket::new(socket2::Domain::IPV4, Type::STREAM, None)?;
+    ///     let poller = polling::Poller::new()?;
+    ///     unsafe {
+    ///         poller.add(&socket, Event::new(0, true, true))?;
+    ///     }
+    ///     let addr = net::SocketAddr::new(net::Ipv4Addr::LOCALHOST.into(), 8080);
+    ///     socket.set_nonblocking(true)?;
+    ///     let _ = socket.connect(&addr.into());
+    ///
+    ///     let mut events = polling::Events::new();
+    ///
+    ///     events.clear();
+    ///     poller.wait(&mut events, None)?;
+    ///
+    ///     let event = events.iter().next();
+    ///     let Some(event) = event else {
+    ///         println!("no event");
+    ///         return Ok(());
+    ///     };
+    ///
+    ///     println!("event: {:?}", event);
+    ///     if event
+    ///         .is_connect_failed()
+    ///         .expect("is connect failed does not support on this platform")
+    ///     {
+    ///         println!("connect failed");
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(true)` if the connection has failed, `Some(false)` if the connection has not failed,
+    /// or `None` if the platform does not support detecting this condition.
     #[inline]
-    pub fn is_connect_failed(&self) -> bool {
+    pub fn is_connect_failed(&self) -> Option<bool> {
         self.extra.is_connect_failed()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,7 @@ impl Event {
     ///     poller.wait(&mut events, None)?;
     ///
     ///     let event = events.iter().next();
-    /// 
+    ///
     ///     let event = match event {
     ///         Some(event) => event,
     ///         None => {

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -431,7 +431,7 @@ impl EventExtra {
     pub fn is_connect_failed(&self) -> bool {
         // need reviewer's special attention, as I do not have access to a system that supports this
         // this is a guess based on the documentation of `poll()`
-        self.flags.contains(PollFlags::ERR)
+        self.flags.contains(PollFlags::ERR) || self.flags.contains(PollFlags::HUP)
     }
 }
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -428,10 +428,8 @@ impl EventExtra {
     }
 
     #[inline]
-    pub fn is_connect_failed(&self) -> bool {
-        // need reviewer's special attention, as I do not have access to a system that supports this
-        // this is a guess based on the documentation of `poll()`
-        self.flags.contains(PollFlags::ERR) || self.flags.contains(PollFlags::HUP)
+    pub fn is_connect_failed(&self) -> Option<bool> {
+        Some(self.flags.contains(PollFlags::ERR) || self.flags.contains(PollFlags::HUP))
     }
 }
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -426,6 +426,13 @@ impl EventExtra {
     pub fn is_pri(&self) -> bool {
         self.flags.contains(PollFlags::PRI)
     }
+
+    #[inline]
+    pub fn is_connect_failed(&self) -> bool {
+        // need reviewer's special attention, as I do not have access to a system that supports this
+        // this is a guess based on the documentation of `poll()`
+        self.flags.contains(PollFlags::ERR)
+    }
 }
 
 fn cvt_mode_as_remove(mode: PollMode) -> io::Result<bool> {

--- a/src/port.rs
+++ b/src/port.rs
@@ -252,7 +252,7 @@ impl EventExtra {
     }
 
     #[inline]
-    pub fn is_connect_failed(&self) -> bool {
+    pub fn is_connect_failed(&self) -> Option<bool> {
         Some(self.flags.contains(PollFlags::ERR) || self.flags.contains(PollFlags::HUP))
     }
 }

--- a/src/port.rs
+++ b/src/port.rs
@@ -253,6 +253,6 @@ impl EventExtra {
 
     #[inline]
     pub fn is_connect_failed(&self) -> bool {
-        self.flags.contains(PollFlags::ERR) || self.flags.contains(PollFlags::HUP)
+        Some(self.flags.contains(PollFlags::ERR) || self.flags.contains(PollFlags::HUP))
     }
 }

--- a/src/port.rs
+++ b/src/port.rs
@@ -250,4 +250,9 @@ impl EventExtra {
     pub fn is_pri(&self) -> bool {
         self.flags.contains(PollFlags::PRI)
     }
+
+    #[inline]
+    pub fn is_connect_failed(&self) -> bool {
+        self.flags.contains(PollFlags::ERR) || self.flags.contains(PollFlags::HUP)
+    }
 }


### PR DESCRIPTION
Added is_connection_failed method to identify if a tcp connection has failed, please see example `tcp_client.rs`. 
Let me know if adding socket2 to dev-dependency is acceptable, I will remove it if not.

address https://github.com/smol-rs/polling/issues/184