### PR TITLE
Annotate ESP-IDF EPERM error with eventfd info

### DIFF
--- a/examples/wait-signal.rs
+++ b/examples/wait-signal.rs
@@ -27,22 +27,16 @@ mod example {
 
         println!("Press Ctrl+C to exit...");
 
-        loop {
-            // Wait for events.
-            poller.wait(&mut events, None).unwrap();
+        // Wait for events.
+        poller.wait(&mut events, None).unwrap();
 
-            // Process events.
-            for ev in events.iter() {
-                match ev.key {
-                    1 => {
-                        println!("SIGINT received");
-                        return;
-                    }
-                    _ => unreachable!(),
-                }
+        // Process events.
+        let ev = events.iter().next().unwrap();
+        match ev.key {
+            1 => {
+                println!("SIGINT received");
             }
-
-            events.clear();
+            _ => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
If eventfd isn't initialized, `Polling::new` will fail with an EPERM
error. You need to call the "esp_vfs_eventfd_register" function to
initialize the eventfd subsystem in ESP-IDF. This commit indicates to
the user that this needs to happen.

Closes #183
