### PR TITLE
v3.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 3.3.3
+
+- On ESP-IDF, there is an EPERM error when initializing the `Poller` without
+  first having initialized the ESP-IDF eventfd subsystem. Now, when this happens
+  the error will mention the need to call "esp_vfs_eventfd_register" first. (#186)
+
 # Version 3.3.2
 
 - When AFD fails to initialize, the resulting error now references

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "polling"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v3.x.y" git tag
-version = "3.3.2"
+version = "3.3.3"
 authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
- On ESP-IDF, there is an EPERM error when initializing the `Poller` without first having initialized the ESP-IDF eventfd subsystem. Now, when this happens the error will mention the need to call "esp_vfs_eventfd_register" first. (#186)
