### PR TITLE
v3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version 3.4.0
+
+- Add the ability to identify whether socket connection has failed. (#185)
+- On BSD, add the ability to wait on a process by its PID. Previously, it was
+  only possible to wait on a process by a `Child` object. (#180)
+- On ESP-IDF, annotate `eventfd` initialization failures with a message
+  indicating the source of those failures. (#186)
+
 # Version 3.3.2
 
 - When AFD fails to initialize, the resulting error now references

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "polling"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v3.x.y" git tag
-version = "3.3.2"
+version = "3.4.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
- Add the ability to identify whether socket connection has failed. (#185)
- On BSD, add the ability to wait on a process by its PID. Previously, it was
  only possible to wait on a process by a `Child` object. (#180)
- On ESP-IDF, annotate `eventfd` initialization failures with a message
  indicating the source of those failures. (#186)
