### PR TITLE
Add RedoxOS Epoll

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,10 @@ jobs:
       run: |
         rustup target add x86_64-unknown-illumos
         cargo build --target x86_64-unknown-illumos
+    - name: Redox
+      run: |
+        rustup target add x86_64-unknown-redox
+        cargo check --target x86_64-unknown-redox
 
   wine:
     runs-on: ubuntu-22.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ cfg-if = "1"
 tracing = { version = "0.1.37", default-features = false }
 
 [target.'cfg(any(unix, target_os = "fuchsia", target_os = "vxworks"))'.dependencies]
-rustix = { version = "0.38.8", features = ["event", "fs", "pipe", "process", "std", "time"], default-features = false }
+rustix = { version = "0.38.31", features = ["event", "fs", "pipe", "process", "std", "time"], default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 concurrent-queue = "2.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Portable interface to epoll, kqueue, event ports, and IOCP.
 //!
 //! Supported platforms:
-//! - [epoll](https://en.wikipedia.org/wiki/Epoll): Linux, Android
+//! - [epoll](https://en.wikipedia.org/wiki/Epoll): Linux, Android, RedoxOS
 //! - [kqueue](https://en.wikipedia.org/wiki/Kqueue): macOS, iOS, tvOS, watchOS, FreeBSD, NetBSD, OpenBSD,
 //!   DragonFly BSD
 //! - [event ports](https://illumos.org/man/port_create): illumos, Solaris
@@ -80,7 +80,11 @@ cfg_if! {
     if #[cfg(polling_test_poll_backend)] {
         mod poll;
         use poll as sys;
-    } else if #[cfg(any(target_os = "linux", target_os = "android"))] {
+    } else if #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "redox"
+    ))] {
         mod epoll;
         use epoll as sys;
     } else if #[cfg(any(

--- a/src/os.rs
+++ b/src/os.rs
@@ -20,6 +20,7 @@ pub mod iocp;
 
 mod __private {
     #[doc(hidden)]
+    #[allow(dead_code)]
     pub trait PollerSealed {}
 
     impl PollerSealed for crate::Poller {}


### PR DESCRIPTION
Technically RedoxOS supports the poll syscall, so we already support
RedoxOS. However, this is very slow. This commit ports this code to
epoll, which should be more efficient.

Closes #176
