### PR TITLE
v3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 3.5.0
+
+- Use the `epoll` backend when RedoxOS is enabled. (#190)
+
 # Version 3.4.0
 
 - Add the ability to identify whether socket connection has failed. (#185)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "polling"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v3.x.y" git tag
-version = "3.4.0"
+version = "3.5.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
- Use the `epoll` backend when RedoxOS is enabled. (#190)
