### PR TITLE
Remove CallOnDrop from port.rs

### DIFF
--- a/src/iocp/port.rs
+++ b/src/iocp/port.rs
@@ -296,11 +296,3 @@ impl<T: CompletionHandle> Drop for OverlappedEntry<T> {
         drop(unsafe { self.packet() });
     }
 }
-
-struct CallOnDrop<F: FnMut()>(F);
-
-impl<F: FnMut()> Drop for CallOnDrop<F> {
-    fn drop(&mut self) {
-        (self.0)();
-    }
-}


### PR DESCRIPTION
CallOnDrop is no longer used in the Windows IOCP backend, and it wasn't
being flagged as unused until the latest nightly. In order to fix
Windows builds, this commit removes CallOnDrop.
