### PR TITLE
v3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 3.6.0
+
+- Add an `is_err` method to `Event` to tell when an error has occurred. (#189)
+- Deprecate the `is_connect_failed` function. (#189)
+- Add support for HermitOS to `polling`. (#194)
+
 # Version 3.5.0
 
 - Use the `epoll` backend when RedoxOS is enabled. (#190)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "polling"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v3.x.y" git tag
-version = "3.5.0"
+version = "3.6.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
- Add an `is_err` method to `Event` to tell when an error has occurred. (#189)
- Deprecate the `is_connect_failed` function. (#189)
- Add support for HermitOS to `polling`. (#194)

