### PR TITLE
feat: ported to Vita target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,10 @@ name = "polling"
 # - Update CHANGELOG.md
 # - Create "v3.x.y" git tag
 version = "3.6.0"
-authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
+authors = [
+    "Stjepan Glavina <stjepang@gmail.com>",
+    "John Nunley <dev@notgull.net>",
+]
 edition = "2021"
 rust-version = "1.63"
 description = "Portable interface to epoll, kqueue, event ports, and IOCP"
@@ -55,4 +58,6 @@ socket2 = "0.5.5"
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = "0.2"
+
+[target.'cfg(all(unix, not(target_os="vita")))'.dev-dependencies]
 signal-hook = "0.3.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,7 @@ name = "polling"
 # - Update CHANGELOG.md
 # - Create "v3.x.y" git tag
 version = "3.6.0"
-authors = [
-    "Stjepan Glavina <stjepang@gmail.com>",
-    "John Nunley <dev@notgull.net>",
-]
+authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
 edition = "2021"
 rust-version = "1.63"
 description = "Portable interface to epoll, kqueue, event ports, and IOCP"

--- a/tests/concurrent_modification.rs
+++ b/tests/concurrent_modification.rs
@@ -76,7 +76,7 @@ fn concurrent_modify() -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(unix, not(target_os = "vita"))]
 #[test]
 fn concurrent_interruption() -> io::Result<()> {
     struct MakeItSend<T>(T);


### PR DESCRIPTION
Fixes #160

### Notes
- `signal-hook` does not compile and won't work on Vita, `pthread_kill` is a stub in Vita `newlib`
- Pipes in Vita newlib do not guarantee that after the write completes, the payload is immediately available on the other side of the pipe. This PR temporarily removes the `NONBLOCK` flag from the read side of the pipe when `wait` detects `notified` before polling