### PR TITLE
Remove +nightly from cross CI job and use "rustup default" instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,12 +85,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Rust
-      run: rustup update ${{ matrix.rust }}
+      run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
     - name: Install cross
       uses: taiki-e/install-action@cross
     - name: Add rust-src
       if: startsWith(matrix.rust, 'nightly')
-      run: rustup +nightly component add rust-src
+      run: rustup component add rust-src
     # We don't test BSDs, since we already test them in Cirrus.
     - name: Android
       if: startsWith(matrix.os, 'ubuntu')
@@ -122,13 +122,13 @@ jobs:
         cargo check --target x86_64-unknown-redox
     - name: HermitOS
       if: startsWith(matrix.rust, 'nightly') && matrix.os == 'ubuntu-latest'
-      run: cargo +nightly check -Z build-std --target x86_64-unknown-hermit
+      run: cargo check -Z build-std --target x86_64-unknown-hermit
     - name: Check haiku
       if: startsWith(matrix.rust, 'nightly') && matrix.os == 'ubuntu-latest'
-      run: cargo +nightly check -Z build-std --target x86_64-unknown-haiku
+      run: cargo check -Z build-std --target x86_64-unknown-haiku
     - name: Check vita
       if: startsWith(matrix.rust, 'nightly') && matrix.os == 'ubuntu-latest'
-      run: cargo +nightly check -Z build-std --target armv7-sony-vita-newlibeabihf
+      run: cargo check -Z build-std --target armv7-sony-vita-newlibeabihf
 
   wine:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Previously in the "cross" CI job, checks would use "+nightly" to ensure
that the nightly compiler is used. However this adds a lot of noise. In
order to clean up CI this commit replaces "+nightly" with "rustup
default nightly" at the start of the job.

cc https://github.com/smol-rs/polling/pull/197#discussion_r1573375732
