### PR TITLE
Use latest stable wine in testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,6 @@ jobs:
       - uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: x86_64-pc-windows-gnu
-          runner: wine@7.13
       - run: cargo test --target x86_64-pc-windows-gnu
 
   msrv:


### PR DESCRIPTION
This works around bugs in Rust v1.78 that introduce incompatibilities
into Wine.

https://github.com/smol-rs/polling/pull/201#issuecomment-2092385046
