### PR TITLE
Fix new nightly errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ exclude = ["/.*"]
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docsrs)', 'cfg(polling_test_poll_backend)', 'cfg(polling_test_epoll_pipe)'] }
+
 [dependencies]
 cfg-if = "1"
 tracing = { version = "0.1.37", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["/.*"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docsrs)', 'cfg(polling_test_poll_backend)', 'cfg(polling_test_epoll_pipe)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(polling_test_poll_backend)', 'cfg(polling_test_epoll_pipe)'] }
 
 [dependencies]
 cfg-if = "1"

--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -201,7 +201,7 @@ impl Poller {
             (_, Some(t)) if t == Duration::from_secs(0) => 0,
             (None, Some(t)) => {
                 // Round up to a whole millisecond.
-                let mut ms = t.as_millis().try_into().unwrap_or(std::i32::MAX);
+                let mut ms = t.as_millis().try_into().unwrap_or(i32::MAX);
                 if Duration::from_millis(ms as u64) < t {
                     ms = ms.saturating_add(1);
                 }


### PR DESCRIPTION
- Use i32::MAX instead of std::i32::MAX
- Add "expected cfg" lints to Cargo.toml
