### PR TITLE
v3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 3.7.1
+
+- Fix a typo in `Event::is_err()`. (#204)
+
 # Version 3.7.0
 
 - Add support for the PS Vita as a platform. (#160)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "polling"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v3.x.y" git tag
-version = "3.7.0"
+version = "3.7.1"
 authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
- Fix a typo in `Event::is_err()`. (#204)
