### PR TITLE
ci: Use reusable workflows for fmt and security_audit & Re-enable ESP-IDF check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,16 @@ defaults:
     shell: bash
 
 jobs:
+  fmt:
+    uses: smol-rs/.github/.github/workflows/fmt.yml@main
+  security_audit:
+    uses: smol-rs/.github/.github/workflows/security_audit.yml@main
+    permissions:
+      checks: write
+      contents: read
+      issues: write
+    secrets: inherit
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -164,27 +174,3 @@ jobs:
       - name: Install Rust
         run: rustup update stable
       - run: cargo clippy --all-features --all-targets
-
-  fmt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust
-        run: rustup update stable
-      - run: cargo fmt --all --check
-
-  security_audit:
-    permissions:
-      checks: write
-      contents: read
-      issues: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      # rustsec/audit-check used to do this automatically
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
-      # https://github.com/rustsec/audit-check/issues/2
-      - uses: rustsec/audit-check@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,6 @@ jobs:
           RUSTFLAGS: ${{ env.RUSTFLAGS }} --cfg polling_test_epoll_pipe
         if: startsWith(matrix.os, 'ubuntu')
       - run: cargo hack build --feature-powerset --no-dev-deps
-      # TODO: broken due to https://github.com/rust-lang/rust/pull/119026.
-      # - name: Check selected Tier 3 targets
-      #   if: startsWith(matrix.rust, 'nightly') && matrix.os == 'ubuntu-latest'
-      #   run: cargo check -Z build-std --target=riscv32imc-esp-espidf
       - name: Clone async-io
         run: git clone https://github.com/smol-rs/async-io.git
         # The async-io Cargo.toml already has a patch section at the bottom, so we
@@ -126,19 +122,22 @@ jobs:
         rustup target add x86_64-unknown-illumos
         cargo build --target x86_64-unknown-illumos
     - name: Redox
-      if: startsWith(matrix.rust, 'nightly') && matrix.os == 'ubuntu-latest'
+      if: startsWith(matrix.rust, 'nightly') && startsWith(matrix.os, 'ubuntu')
       run: |
         rustup target add x86_64-unknown-redox
         cargo check --target x86_64-unknown-redox
     - name: HermitOS
-      if: startsWith(matrix.rust, 'nightly') && matrix.os == 'ubuntu-latest'
+      if: startsWith(matrix.rust, 'nightly') && startsWith(matrix.os, 'ubuntu')
       run: cargo check -Z build-std --target x86_64-unknown-hermit
     - name: Check haiku
-      if: startsWith(matrix.rust, 'nightly') && matrix.os == 'ubuntu-latest'
+      if: startsWith(matrix.rust, 'nightly') && startsWith(matrix.os, 'ubuntu')
       run: cargo check -Z build-std --target x86_64-unknown-haiku
     - name: Check vita
-      if: startsWith(matrix.rust, 'nightly') && matrix.os == 'ubuntu-latest'
+      if: startsWith(matrix.rust, 'nightly') && startsWith(matrix.os, 'ubuntu')
       run: cargo check -Z build-std --target armv7-sony-vita-newlibeabihf
+    - name: Check ESP-IDF
+      if: startsWith(matrix.rust, 'nightly') && startsWith(matrix.os, 'ubuntu')
+      run: cargo check -Z build-std --target riscv32imc-esp-espidf
 
   wine:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
See https://github.com/smol-rs/.github/pull/1 for details about reusable workflows.
