### PR TITLE
Port to rustix 1.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ cfg-if = "1"
 tracing = { version = "0.1.37", default-features = false }
 
 [target.'cfg(any(unix, target_os = "fuchsia", target_os = "vxworks"))'.dependencies.rustix]
-version = "1.0.4"
+version = "1.0.5"
 features = ["event", "fs", "pipe", "process", "std", "time"]
 default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ cfg-if = "1"
 tracing = { version = "0.1.37", default-features = false }
 
 [target.'cfg(any(unix, target_os = "fuchsia", target_os = "vxworks"))'.dependencies.rustix]
-version = "1.0.3"
+version = "1.0.4"
 features = ["event", "fs", "pipe", "process", "std", "time"]
 default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ cfg-if = "1"
 tracing = { version = "0.1.37", default-features = false }
 
 [target.'cfg(any(unix, target_os = "fuchsia", target_os = "vxworks"))'.dependencies.rustix]
-version = "0.38.31"
+version = "1.0.3"
 features = ["event", "fs", "pipe", "process", "std", "time"]
 default-features = false
 

--- a/examples/wait-signal.rs
+++ b/examples/wait-signal.rs
@@ -17,7 +17,7 @@ mod example {
         let poller = Poller::new().unwrap();
 
         // Register SIGINT in the poller.
-        let sigint = Signal(rustix::process::Signal::Int as _);
+        let sigint = Signal(rustix::process::Signal::INT as _);
         poller.add_filter(sigint, 1, PollMode::Oneshot).unwrap();
 
         let mut events = Events::new();

--- a/examples/wait-signal.rs
+++ b/examples/wait-signal.rs
@@ -17,7 +17,7 @@ mod example {
         let poller = Poller::new().unwrap();
 
         // Register SIGINT in the poller.
-        let sigint = Signal(rustix::process::Signal::INT as _);
+        let sigint = Signal(rustix::process::Signal::INT.as_raw());
         poller.add_filter(sigint, 1, PollMode::Oneshot).unwrap();
 
         let mut events = Events::new();

--- a/src/epoll.rs
+++ b/src/epoll.rs
@@ -9,13 +9,13 @@ use rustix::event::{eventfd, EventfdFlags};
 #[cfg(not(target_os = "redox"))]
 use rustix::time::{
     timerfd_create, timerfd_settime, Itimerspec, TimerfdClockId, TimerfdFlags, TimerfdTimerFlags,
-    Timespec,
 };
 
-use rustix::event::epoll;
+use rustix::buffer::spare_capacity;
+use rustix::event::{epoll, Timespec};
 use rustix::fd::OwnedFd;
 use rustix::fs::{fcntl_getfl, fcntl_setfl, OFlags};
-use rustix::io::{fcntl_getfd, fcntl_setfd, read, write, FdFlags};
+use rustix::io::{fcntl_getfd, fcntl_setfd, read, write, Errno, FdFlags};
 use rustix::pipe::{pipe, pipe_with, PipeFlags};
 
 use crate::{Event, PollMode};
@@ -196,22 +196,19 @@ impl Poller {
         #[cfg(target_os = "redox")]
         let timer_fd: Option<core::convert::Infallible> = None;
 
-        // Timeout in milliseconds for epoll.
-        let timeout_ms = match (timer_fd, timeout) {
-            (_, Some(t)) if t == Duration::from_secs(0) => 0,
-            (None, Some(t)) => {
-                // Round up to a whole millisecond.
-                let mut ms = t.as_millis().try_into().unwrap_or(i32::MAX);
-                if Duration::from_millis(ms as u64) < t {
-                    ms = ms.saturating_add(1);
-                }
-                ms
-            }
-            _ => -1,
+        // Timeout for epoll.
+        let timeout = match (timer_fd, timeout) {
+            (_, Some(t)) if t == Duration::from_secs(0) => Some(Timespec::default()),
+            (None, Some(t)) => Some(Timespec::try_from(t).map_err(|_| Errno::INVAL)?),
+            _ => None,
         };
 
         // Wait for I/O events.
-        epoll::wait(&self.epoll_fd, &mut events.list, timeout_ms)?;
+        epoll::wait(
+            &self.epoll_fd,
+            spare_capacity(&mut events.list),
+            timeout.as_ref(),
+        )?;
         tracing::trace!(
             epoll_fd = ?self.epoll_fd.as_raw_fd(),
             res = ?events.list.len(),
@@ -306,7 +303,7 @@ fn write_flags() -> epoll::EventFlags {
 
 /// A list of reported I/O events.
 pub struct Events {
-    list: epoll::EventVec,
+    list: Vec<epoll::Event>,
 }
 
 unsafe impl Send for Events {}
@@ -315,7 +312,7 @@ impl Events {
     /// Creates an empty list.
     pub fn with_capacity(cap: usize) -> Events {
         Events {
-            list: epoll::EventVec::with_capacity(cap),
+            list: Vec::with_capacity(cap),
         }
     }
 

--- a/src/iocp/mod.rs
+++ b/src/iocp/mod.rs
@@ -430,7 +430,6 @@ impl Poller {
         // Make sure we have a consistent timeout.
         let deadline = timeout.and_then(|timeout| Instant::now().checked_add(timeout));
         let mut notified = false;
-        events.packets.clear();
 
         loop {
             let mut new_events = 0;

--- a/src/os/kqueue.rs
+++ b/src/os/kqueue.rs
@@ -38,7 +38,7 @@ pub trait PollerKqueueExt<F: Filter>: PollerSealed {
     /// let poller = Poller::new().unwrap();
     ///
     /// // Register the SIGINT signal.
-    /// poller.add_filter(Signal(rustix::process::Signal::Int as _), 0, PollMode::Oneshot).unwrap();
+    /// poller.add_filter(Signal(rustix::process::Signal::INT.as_raw()), 0, PollMode::Oneshot).unwrap();
     ///
     /// // Wait for the signal.
     /// let mut events = Events::new();
@@ -61,10 +61,10 @@ pub trait PollerKqueueExt<F: Filter>: PollerSealed {
     /// let poller = Poller::new().unwrap();
     ///
     /// // Register the SIGINT signal.
-    /// poller.add_filter(Signal(rustix::process::Signal::Int as _), 0, PollMode::Oneshot).unwrap();
+    /// poller.add_filter(Signal(rustix::process::Signal::INT.as_raw()), 0, PollMode::Oneshot).unwrap();
     ///
     /// // Re-register with a different key.
-    /// poller.modify_filter(Signal(rustix::process::Signal::Int as _), 1, PollMode::Oneshot).unwrap();
+    /// poller.modify_filter(Signal(rustix::process::Signal::INT.as_raw()), 1, PollMode::Oneshot).unwrap();
     ///
     /// // Wait for the signal.
     /// let mut events = Events::new();
@@ -87,10 +87,10 @@ pub trait PollerKqueueExt<F: Filter>: PollerSealed {
     /// let poller = Poller::new().unwrap();
     ///
     /// // Register the SIGINT signal.
-    /// poller.add_filter(Signal(rustix::process::Signal::Int as _), 0, PollMode::Oneshot).unwrap();
+    /// poller.add_filter(Signal(rustix::process::Signal::INT.as_raw()), 0, PollMode::Oneshot).unwrap();
     ///
     /// // Remove the filter.
-    /// poller.delete_filter(Signal(rustix::process::Signal::Int as _)).unwrap();
+    /// poller.delete_filter(Signal(rustix::process::Signal::INT.as_raw())).unwrap();
     /// ```
     fn delete_filter(&self, filter: F) -> io::Result<()>;
 }

--- a/src/os/kqueue.rs
+++ b/src/os/kqueue.rs
@@ -153,7 +153,8 @@ unsafe impl FilterSealed for Signal {
     fn filter(&self, flags: kqueue::EventFlags, key: usize) -> kqueue::Event {
         kqueue::Event::new(
             kqueue::EventFilter::Signal {
-                signal: rustix::process::Signal::from_raw(self.0).expect("invalid signal number"),
+                signal: rustix::process::Signal::from_named_raw(self.0)
+                    .expect("invalid signal number"),
                 times: 0,
             },
             flags | kqueue::EventFlags::RECEIPT,

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -448,7 +448,6 @@ mod syscall {
     pub(super) use rustix::event::{eventfd, EventfdFlags};
     #[cfg(target_os = "espidf")]
     pub(super) use rustix::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
-    pub(super) use rustix::io::Errno;
     #[cfg(target_os = "espidf")]
     pub(super) use rustix::io::{read, write};
     use std::io;

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -212,8 +212,6 @@ impl Poller {
 
         let deadline = timeout.and_then(|t| Instant::now().checked_add(t));
 
-        events.inner.clear();
-
         let mut fds = self.fds.lock().unwrap();
 
         loop {

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -456,9 +456,9 @@ mod syscall {
 
     /// Safe wrapper around the `poll` system call.
     pub(super) fn poll(fds: &mut [PollFd<'_>], timeout: Option<Duration>) -> io::Result<usize> {
-        // Timeout for `poll`.
+        // Timeout for `poll`. In case of overflow, use no timeout.
         let timeout = match timeout {
-            Some(timeout) => Some(Timespec::try_from(timeout).map_err(|_| Errno::INVAL)?),
+            Some(timeout) => Timespec::try_from(timeout).ok(),
             None => None,
         };
 

--- a/src/port.rs
+++ b/src/port.rs
@@ -4,6 +4,7 @@ use std::io;
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::time::Duration;
 
+use rustix::buffer::spare_capacity;
 use rustix::event::{port, PollFlags, Timespec};
 use rustix::fd::OwnedFd;
 use rustix::io::{fcntl_getfd, fcntl_setfd, Errno, FdFlags};
@@ -119,7 +120,12 @@ impl Poller {
         };
 
         // Wait for I/O events.
-        let res = port::getn(&self.port_fd, &mut events.list, 1, timeout.as_ref());
+        let res = port::getn(
+            &self.port_fd,
+            spare_capacity(&mut events.list),
+            1,
+            timeout.as_ref(),
+        );
         tracing::trace!(
             port_fd = ?self.port_fd,
             res = ?events.list.len(),

--- a/src/port.rs
+++ b/src/port.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use rustix::buffer::spare_capacity;
 use rustix::event::{port, PollFlags, Timespec};
 use rustix::fd::OwnedFd;
-use rustix::io::{fcntl_getfd, fcntl_setfd, Errno, FdFlags};
+use rustix::io::{fcntl_getfd, fcntl_setfd, FdFlags};
 
 use crate::{Event, PollMode};
 
@@ -113,9 +113,9 @@ impl Poller {
         );
         let _enter = span.enter();
 
-        // Timeout for `port::getn`.
+        // Timeout for `port::getn`. In case of overflow, use no timeout.
         let timeout = match timeout {
-            Some(t) => Some(Timespec::try_from(t).map_err(|_| Errno::INVAL)?),
+            Some(t) => Timespec::try_from(t).ok(),
             None => None,
         };
 

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -132,7 +132,7 @@ fn append_events() {
     }
 
     for (read, _write) in &pairs {
-        poller.delete(&read).unwrap();
+        poller.delete(read).unwrap();
     }
 }
 

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -81,6 +81,61 @@ fn insert_twice() {
     poller.delete(&read).unwrap();
 }
 
+/// Test that calling `wait` appends events, as [documented], rather than
+/// overwriting them.
+///
+/// [documented]: https://docs.rs/polling/latest/polling/struct.Poller.html#method.wait
+#[test]
+fn append_events() {
+    #[cfg(unix)]
+    use std::os::unix::io::AsRawFd;
+    #[cfg(windows)]
+    use std::os::windows::io::AsRawSocket;
+
+    // Create a few sockets.
+    let mut pairs = Vec::new();
+    for _ in 0..4 {
+        let (read, write) = tcp_pair().unwrap();
+        pairs.push((read, write));
+    }
+
+    // Add the sockets to the poller.
+    let poller = Poller::new().unwrap();
+    unsafe {
+        for (read, _write) in &pairs {
+            #[cfg(unix)]
+            let read = read.as_raw_fd();
+            #[cfg(windows)]
+            let read = read.as_raw_socket();
+
+            poller.add(read, Event::readable(1)).unwrap();
+        }
+    }
+
+    // Trigger read events on the sockets and reuse the event list to test
+    // that events are appended.
+    let mut events = Events::new();
+
+    for (index, (_read, ref mut write)) in pairs.iter_mut().enumerate() {
+        // Write to the socket prompting a reader readiness event.
+        write.write_all(&[1]).unwrap();
+        assert_eq!(
+            poller
+                .wait(&mut events, Some(Duration::from_secs(1)))
+                .unwrap(),
+            index + 1
+        );
+        assert_eq!(events.len(), index + 1);
+        for event in events.iter() {
+            assert_eq!(event.with_no_extra(), Event::readable(1));
+        }
+    }
+
+    for (read, _write) in &pairs {
+        poller.delete(&read).unwrap();
+    }
+}
+
 fn tcp_pair() -> io::Result<(TcpStream, TcpStream)> {
     let listener = TcpListener::bind("127.0.0.1:0")?;
     let a = TcpStream::connect(listener.local_addr()?)?;


### PR DESCRIPTION
rustix 1.0 introduced a new [`Buffer`] API which is used in `epoll::wait`, `kqueue`, and `polling`, so this patch updates the code to use the new [`spare_capacity`] mechanism for writing to the spare capacity of a `Vec`.

rustix 1.0 also changes timeout parameters from `i32` milliseconds to `Timespec` seconds plus nanoseconds, which is more general and aligns with newer Linux syscalls such as [`epoll_pwait2`].

This also fixes a bug in the `wait` function; in rustix 0.38, calling `epoll::wait` would clear the events list before adding new events, however polling's documentation [states] that "New events will be appended to `events`." Using `spare_capacity` in rustix 1.0, the list is not cleared first, so events are appended.

Closes #234.

[`Buffer`]: https://docs.rs/rustix/latest/rustix/buffer/trait.Buffer.html
[`spare_capacity`]: https://docs.rs/rustix/latest/rustix/buffer/fn.spare_capacity.html
[`epoll_pwait2`]: https://www.man7.org/linux/man-pages/man2/epoll_pwait2.2.html
[states]: https://docs.rs/polling/latest/polling/struct.Poller.html#method.wait