### PR TITLE
Release 3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 3.8.0
+
+- Implement `AsRawFd` and `AsFd` for `Poller` on Redox OS. (#235)
+- Update `hermit-abi` to v0.5.0. (#229)
+
 # Version 3.7.4
 
 - Add support for visionOS. (#217)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Implement `AsRawFd` and `AsFd` for `Poller` on Redox OS. (#235)
 - Update `hermit-abi` to v0.5.0. (#229)
+- Update `rustix` to 1.0 (#230). This also fixed a bug in `wait` which (contradicting docs) cleared the events vector instead of appending to it.
+- Add support for QNX (#201)
 
 # Version 3.7.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Implement `AsRawFd` and `AsFd` for `Poller` on Redox OS. (#235)
 - Update `hermit-abi` to v0.5.0. (#229)
 - Update `rustix` to 1.0 (#230). This also fixed a bug in `wait` which (contradicting docs) cleared the events vector instead of appending to it.
-- Add support for QNX (#201)
+- Add support for QNX. (#201)
 
 # Version 3.7.4
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "polling"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v3.x.y" git tag
-version = "3.7.4"
+version = "3.8.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
Changes:

- Implement `AsRawFd` and `AsFd` for `Poller` on Redox OS. (#235)
- Update `hermit-abi` to v0.5.0. (#229)
- Update `rustix` to 1.0 (#230). This also fixed a bug in `wait` which (contradicting docs) cleared the events vector instead of appending to it.
- Add support for QNX. (#201)