### PR TITLE
fix: making `tracing` integration optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,11 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(polling_test_poll_backend)
 
 [dependencies]
 cfg-if = "1"
-tracing = { version = "0.1.37", default-features = false }
+
+[dependencies.tracing]
+version = "0.1.37"
+default-features = false
+optional = true
 
 [target.'cfg(any(unix, target_os = "fuchsia", target_os = "vxworks"))'.dependencies.rustix]
 version = "1.0.5"

--- a/examples/tcp_client.rs
+++ b/examples/tcp_client.rs
@@ -27,7 +27,7 @@ fn main() -> io::Result<()> {
         }
     };
 
-    println!("event: {:?}", event);
+    println!("event: {event:?}");
     if event.is_err().unwrap_or(false) {
         println!("connect failed");
     }

--- a/src/iocp/afd.rs
+++ b/src/iocp/afd.rs
@@ -197,6 +197,7 @@ macro_rules! define_ntdll_import {
                         let addr = match addr {
                             Some(addr) => addr,
                             None => {
+                                #[cfg(feature = "tracing")]
                                 tracing::error!("Failed to load ntdll function {}", NAME);
                                 return Err(io::Error::last_os_error());
                             },
@@ -298,6 +299,7 @@ impl NtdllImports {
                 let ntdll = GetModuleHandleW(NTDLL_NAME.as_ptr() as *const _);
 
                 if ntdll.is_null() {
+                    #[cfg(feature = "tracing")]
                     tracing::error!("Failed to load ntdll.dll");
                     return Err(io::Error::last_os_error());
                 }

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -63,6 +63,7 @@ impl Poller {
         // Register the notification pipe.
         poller.notify.register(&poller)?;
 
+        #[cfg(feature = "tracing")]
         tracing::trace!(
             kqueue_fd = ?poller.kqueue_fd.as_raw_fd(),
             "new"
@@ -94,6 +95,7 @@ impl Poller {
 
     /// Modifies an existing file descriptor.
     pub fn modify(&self, fd: BorrowedFd<'_>, ev: Event, mode: PollMode) -> io::Result<()> {
+        #[cfg(feature = "tracing")]
         let span = if !self.notify.has_fd(fd) {
             let span = tracing::trace_span!(
                 "add",
@@ -105,6 +107,7 @@ impl Poller {
         } else {
             None
         };
+        #[cfg(feature = "tracing")]
         let _enter = span.as_ref().map(|s| s.enter());
 
         self.has_source(SourceId::Fd(fd.as_raw_fd()))?;
@@ -233,11 +236,13 @@ impl Poller {
 
     /// Waits for I/O events with an optional timeout.
     pub fn wait(&self, events: &mut Events, timeout: Option<Duration>) -> io::Result<()> {
+        #[cfg(feature = "tracing")]
         let span = tracing::trace_span!(
             "wait",
             kqueue_fd = ?self.kqueue_fd.as_raw_fd(),
             ?timeout,
         );
+        #[cfg(feature = "tracing")]
         let _enter = span.enter();
 
         // Timeout for kevent. In case of overflow, use no timeout.
@@ -248,7 +253,7 @@ impl Poller {
 
         // Wait for I/O events.
         let changelist = [];
-        let res = unsafe {
+        let _res = unsafe {
             kqueue::kevent_timespec(
                 &self.kqueue_fd,
                 &changelist,
@@ -257,9 +262,10 @@ impl Poller {
             )?
         };
 
+        #[cfg(feature = "tracing")]
         tracing::trace!(
             kqueue_fd = ?self.kqueue_fd.as_raw_fd(),
-            ?res,
+            res = ?_res,
             "new events",
         );
 
@@ -271,10 +277,12 @@ impl Poller {
 
     /// Sends a notification to wake up the current or next `wait()` call.
     pub fn notify(&self) -> io::Result<()> {
+        #[cfg(feature = "tracing")]
         let span = tracing::trace_span!(
             "notify",
             kqueue_fd = ?self.kqueue_fd.as_raw_fd(),
         );
+        #[cfg(feature = "tracing")]
         let _enter = span.enter();
 
         self.notify.notify(self).ok();
@@ -421,6 +429,7 @@ mod notify {
     use super::Poller;
     use rustix::event::kqueue;
     use std::io;
+    #[cfg(feature = "tracing")]
     use std::os::unix::io::BorrowedFd;
 
     /// A notification pipe.
@@ -486,6 +495,7 @@ mod notify {
         }
 
         /// Whether this raw file descriptor is associated with this pipe.
+        #[cfg(feature = "tracing")]
         pub(super) fn has_fd(&self, _fd: BorrowedFd<'_>) -> bool {
             false
         }
@@ -501,8 +511,10 @@ mod notify {
     use super::Poller;
     use crate::{Event, PollMode, NOTIFY_KEY};
     use std::io::{self, prelude::*};
+    #[cfg(feature = "tracing")]
+    use std::os::unix::io::BorrowedFd;
     use std::os::unix::{
-        io::{AsFd, AsRawFd, BorrowedFd},
+        io::{AsFd, AsRawFd},
         net::UnixStream,
     };
 
@@ -572,6 +584,7 @@ mod notify {
         }
 
         /// Whether this raw file descriptor is associated with this pipe.
+        #[cfg(feature = "tracing")]
         pub(super) fn has_fd(&self, fd: BorrowedFd<'_>) -> bool {
             self.read_stream.as_raw_fd() == fd.as_raw_fd()
         }

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -304,10 +304,12 @@ impl AsFd for Poller {
 
 impl Drop for Poller {
     fn drop(&mut self) {
+        #[cfg(feature = "tracing")]
         let span = tracing::trace_span!(
             "drop",
             kqueue_fd = ?self.kqueue_fd.as_raw_fd(),
         );
+        #[cfg(feature = "tracing")]
         let _enter = span.enter();
 
         let _ = self.notify.deregister(self);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -729,7 +729,9 @@ impl Poller {
     /// # std::io::Result::Ok(())
     /// ```
     pub fn wait(&self, events: &mut Events, timeout: Option<Duration>) -> io::Result<usize> {
+        #[cfg(feature = "tracing")]
         let span = tracing::trace_span!("Poller::wait", ?timeout);
+        #[cfg(feature = "tracing")]
         let _enter = span.enter();
 
         if let Ok(_lock) = self.lock.try_lock() {
@@ -758,6 +760,7 @@ impl Poller {
                 return Ok(events.len());
             }
         } else {
+            #[cfg(feature = "tracing")]
             tracing::trace!("wait: skipping because another thread is already waiting on I/O");
             Ok(0)
         }
@@ -786,7 +789,9 @@ impl Poller {
     /// # std::io::Result::Ok(())
     /// ```
     pub fn notify(&self) -> io::Result<()> {
+        #[cfg(feature = "tracing")]
         let span = tracing::trace_span!("Poller::notify");
+        #[cfg(feature = "tracing")]
         let _enter = span.enter();
 
         if self

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -70,6 +70,7 @@ impl Poller {
     pub fn new() -> io::Result<Poller> {
         let notify = notify::Notify::new()?;
 
+        #[cfg(feature = "tracing")]
         tracing::trace!(?notify, "new");
 
         Ok(Self {
@@ -104,12 +105,14 @@ impl Poller {
             return Err(io::Error::from(io::ErrorKind::InvalidInput));
         }
 
+        #[cfg(feature = "tracing")]
         let span = tracing::trace_span!(
             "add",
             notify_read = ?self.notify.fd().as_raw_fd(),
             ?fd,
             ?ev,
         );
+        #[cfg(feature = "tracing")]
         let _enter = span.enter();
 
         self.modify_fds(|fds| {
@@ -143,12 +146,14 @@ impl Poller {
             return Err(io::Error::from(io::ErrorKind::InvalidInput));
         }
 
+        #[cfg(feature = "tracing")]
         let span = tracing::trace_span!(
             "modify",
             notify_read = ?self.notify.fd().as_raw_fd(),
             ?fd,
             ?ev,
         );
+        #[cfg(feature = "tracing")]
         let _enter = span.enter();
 
         self.modify_fds(|fds| {
@@ -177,11 +182,13 @@ impl Poller {
             return Err(io::Error::from(io::ErrorKind::InvalidInput));
         }
 
+        #[cfg(feature = "tracing")]
         let span = tracing::trace_span!(
             "delete",
             notify_read = ?self.notify.fd().as_raw_fd(),
             ?fd,
         );
+        #[cfg(feature = "tracing")]
         let _enter = span.enter();
 
         self.modify_fds(|fds| {
@@ -203,11 +210,13 @@ impl Poller {
 
     /// Waits for I/O events with an optional timeout.
     pub fn wait(&self, events: &mut Events, timeout: Option<Duration>) -> io::Result<()> {
+        #[cfg(feature = "tracing")]
         let span = tracing::trace_span!(
             "wait",
             notify_read = ?self.notify.fd().as_raw_fd(),
             ?timeout,
         );
+        #[cfg(feature = "tracing")]
         let _enter = span.enter();
 
         let deadline = timeout.and_then(|t| Instant::now().checked_add(t));
@@ -235,6 +244,7 @@ impl Poller {
             let num_events = poll(&mut fds.poll_fds, timeout)?;
             let notified = !fds.poll_fds[0].revents().is_empty();
             let num_fd_events = if notified { num_events - 1 } else { num_events };
+            #[cfg(feature = "tracing")]
             tracing::trace!(?num_events, ?notified, ?num_fd_events, "new events",);
 
             // Read all notifications.
@@ -288,10 +298,12 @@ impl Poller {
 
     /// Sends a notification to wake up the current or next `wait()` call.
     pub fn notify(&self) -> io::Result<()> {
+        #[cfg(feature = "tracing")]
         let span = tracing::trace_span!(
             "notify",
             notify_read = ?self.notify.fd().as_raw_fd(),
         );
+        #[cfg(feature = "tracing")]
         let _enter = span.enter();
 
         if !self.notified.swap(true, Ordering::SeqCst) {

--- a/src/port.rs
+++ b/src/port.rs
@@ -25,6 +25,7 @@ impl Poller {
         let flags = fcntl_getfd(&port_fd)?;
         fcntl_setfd(&port_fd, flags | FdFlags::CLOEXEC)?;
 
+        #[cfg(feature = "tracing")]
         tracing::trace!(
             port_fd = ?port_fd.as_raw_fd(),
             "new",
@@ -55,12 +56,14 @@ impl Poller {
 
     /// Modifies an existing file descriptor.
     pub fn modify(&self, fd: BorrowedFd<'_>, ev: Event, mode: PollMode) -> io::Result<()> {
+        #[cfg(feature = "tracing")]
         let span = tracing::trace_span!(
             "modify",
             port_fd = ?self.port_fd.as_raw_fd(),
             ?fd,
             ?ev,
         );
+        #[cfg(feature = "tracing")]
         let _enter = span.enter();
 
         let mut flags = PollFlags::empty();
@@ -86,11 +89,13 @@ impl Poller {
 
     /// Deletes a file descriptor.
     pub fn delete(&self, fd: BorrowedFd<'_>) -> io::Result<()> {
+        #[cfg(feature = "tracing")]
         let span = tracing::trace_span!(
             "delete",
             port_fd = ?self.port_fd.as_raw_fd(),
             ?fd,
         );
+        #[cfg(feature = "tracing")]
         let _enter = span.enter();
 
         let result = unsafe { port::dissociate_fd(&self.port_fd, fd) };
@@ -106,11 +111,13 @@ impl Poller {
 
     /// Waits for I/O events with an optional timeout.
     pub fn wait(&self, events: &mut Events, timeout: Option<Duration>) -> io::Result<()> {
+        #[cfg(feature = "tracing")]
         let span = tracing::trace_span!(
             "wait",
             port_fd = ?self.port_fd.as_raw_fd(),
             ?timeout,
         );
+        #[cfg(feature = "tracing")]
         let _enter = span.enter();
 
         // Timeout for `port::getn`. In case of overflow, use no timeout.
@@ -126,6 +133,7 @@ impl Poller {
             1,
             timeout.as_ref(),
         );
+        #[cfg(feature = "tracing")]
         tracing::trace!(
             port_fd = ?self.port_fd,
             res = ?events.list.len(),
@@ -149,10 +157,12 @@ impl Poller {
     pub fn notify(&self) -> io::Result<()> {
         const PORT_SOURCE_USER: i32 = 3;
 
+        #[cfg(feature = "tracing")]
         let span = tracing::trace_span!(
             "notify",
             port_fd = ?self.port_fd.as_raw_fd(),
         );
+        #[cfg(feature = "tracing")]
         let _enter = span.enter();
 
         // Use port_send to send a notification to the port.

--- a/tests/many_connections.rs
+++ b/tests/many_connections.rs
@@ -43,7 +43,7 @@ fn many_connections() {
 
         // Check that the connection is readable.
         let current_events = events.iter().collect::<Vec<_>>();
-        assert_eq!(current_events.len(), 1, "events: {:?}", current_events);
+        assert_eq!(current_events.len(), 1, "events: {current_events:?}");
         assert_eq!(
             current_events[0].with_no_extra(),
             polling::Event::readable(id)

--- a/tests/precision.rs
+++ b/tests/precision.rs
@@ -18,7 +18,7 @@ fn below_ms() -> io::Result<()> {
         let elapsed = now.elapsed();
 
         assert_eq!(n, 0);
-        assert!(elapsed >= dur, "{:?} < {:?}", elapsed, dur);
+        assert!(elapsed >= dur, "{elapsed:?} < {dur:?}");
         lowest = lowest.min(elapsed);
     }
 
@@ -51,7 +51,7 @@ fn above_ms() -> io::Result<()> {
         let elapsed = now.elapsed();
 
         assert_eq!(n, 0);
-        assert!(elapsed >= dur, "{:?} < {:?}", elapsed, dur);
+        assert!(elapsed >= dur, "{elapsed:?} < {dur:?}");
         lowest = lowest.min(elapsed);
     }
 


### PR DESCRIPTION
They are now disabled by default and can be enabled using the feature flag `tracing_in_drop` if necessary.

Closes #231.