### PR TITLE
Add  file handle support for overlapped I/O

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# Version 3.12.0
+
+- Add Windows file-handle (named pipe / file / device) support to the IOCP
+  backend via the new `PollerIocpFileExt` trait, `RegisteredFile`,
+  `OpHandle`, and `Submission`. (#248)
+- `OpHandle::take` and `OpHandle::try_take` now return the buffer alongside the
+  result on both success and failure paths (mirrors `compio::BufResult<T, B>`):
+  - `take(self) -> (io::Result<usize>, B)` (was `io::Result<(usize, B)>`)
+  - `try_take(self) -> Result<(io::Result<usize>, B), Self>` (was
+    `Result<io::Result<(usize, B)>, Self>`)
+  This lets the caller reclaim or drop the buffer on error. `cancel(&self)` is
+  unchanged; the buffer is recovered through the subsequent `take`/`try_take`.
+  (#248)
+- Bump MSRV to 1.77 (required by `std::mem::offset_of!`). (#248)
+
 # Version 3.11.0
 
 - Bump MSRV to 1.71. (#251)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,12 @@ name = "polling"
 # - Update CHANGELOG.md
 # - Create "v3.x.y" git tag
 version = "3.11.0"
-authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
+authors = [
+    "Stjepan Glavina <stjepang@gmail.com>",
+    "John Nunley <dev@notgull.net>",
+]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.77"
 description = "Portable interface to epoll, kqueue, event ports, and IOCP"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/smol-rs/polling"
@@ -18,7 +21,10 @@ exclude = ["/.*"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(polling_test_poll_backend)', 'cfg(polling_test_epoll_pipe)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(polling_test_poll_backend)',
+    'cfg(polling_test_epoll_pipe)',
+] }
 
 [dependencies]
 cfg-if = "1"
@@ -50,6 +56,7 @@ features = [
     "Win32_System_LibraryLoader",
     "Win32_System_Threading",
     "Win32_System_WindowsProgramming",
+    "Win32_System_Pipes",
 ]
 
 [target.'cfg(target_os = "hermit")'.dependencies.hermit-abi]
@@ -65,3 +72,6 @@ libc = "0.2"
 
 [target.'cfg(all(unix, not(target_os="vita")))'.dev-dependencies]
 signal-hook = "0.4"
+
+[target.'cfg(windows)'.dev-dependencies]
+tempfile = "3.7"

--- a/docs/named-pipe.design.md
+++ b/docs/named-pipe.design.md
@@ -1,0 +1,679 @@
+# Windows Named Pipe / File Handle Overlapped I/O — Design
+
+> Companion document:
+> [`named-pipe.implement.checklist.md`](./named-pipe.implement.checklist.md)
+> tracks the step-by-step implementation history.
+
+This document describes the **current** IOCP file-handle support shipped
+on the `kail/windows_file` branch (PR
+[smol-rs/polling#248](https://github.com/smol-rs/polling/pull/248)).
+It is the canonical design reference: the rationale for the chosen
+shape, the alternatives that were rejected, and the invariants the
+implementation relies on are all captured here.
+
+The branch adds first-class support for arbitrary Windows overlapped
+file handles (regular files, named pipes, anonymous pipes, mailslots,
+serial ports, …) to the IOCP backend, in addition to the existing
+socket and waitable handle support, via a small completion-based
+`RegisteredFile` / `OpHandle<B>` / `Submission<B>` surface.
+
+---
+
+## 1. Overview
+
+### 1.1 Files
+
+| File | Role |
+|------|------|
+| [Cargo.toml](../Cargo.toml) | MSRV 1.77 (for `offset_of!`); adds `Win32_System_Pipes`; dev-dep `tempfile`. |
+| [src/iocp/ntdll.rs](../src/iocp/ntdll.rs) | `NtdllImports` (incl. `RtlNtStatusToDosError`), shared with `port.rs`. |
+| [src/iocp/buf.rs](../src/iocp/buf.rs) | `StableBuf` / `StableBufMut` traits and blanket impls (`Vec<u8>`, `Box<[u8]>`, `&'static [u8]`, `()`). |
+| [src/iocp/port.rs](../src/iocp/port.rs) | `FileOverlapped` / `FileCompletionHandle` traits, dual-namespace `CompletionKey`, file-vs-socket completion routing. |
+| [src/iocp/mod.rs](../src/iocp/mod.rs) | `PacketInner::FileOp { op: OpInner }`, `RegisteredFileInner`, `Poller::register_file`, `RegisteredFile` / `OpHandle<B>` / `Submission<B>`, dispatcher event-emission for file ops. |
+| [src/os/iocp.rs](../src/os/iocp.rs) | Public `PollerIocpFileExt::register_file` and re-exports of `RegisteredFile`, `OpHandle`, `Submission`, `StableBuf`, `StableBufMut`. |
+| [tests/windows_overlapped.rs](../tests/windows_overlapped.rs), [tests/file_concurrent.rs](../tests/file_concurrent.rs), [tests/file_lifetime.rs](../tests/file_lifetime.rs) | Integration tests; helpers in [tests/common/mod.rs](../tests/common/mod.rs). |
+| [examples/named_pipe.rs](../examples/named_pipe.rs), [examples/named_pipe_concurrent.rs](../examples/named_pipe_concurrent.rs) | End-to-end usage examples. |
+
+### 1.2 Public API
+
+```rust
+use polling::os::iocp::{
+    PollerIocpFileExt, RegisteredFile, OpHandle, Submission,
+    StableBuf, StableBufMut,
+};
+
+trait PollerIocpFileExt {
+    /// Attach `file` to the IOCP and return a long-lived registration
+    /// token. `key` is mirrored into `Event::key` of every completion
+    /// this file emits.
+    unsafe fn register_file(
+        &self,
+        file: impl AsRawFileHandle,
+        key: usize,
+    ) -> io::Result<RegisteredFile>;
+}
+
+impl RegisteredFile {
+    fn submit_read<B: StableBufMut>(&self, buf: B) -> Submission<B>;
+    fn submit_write<B: StableBuf>(&self, buf: B) -> Submission<B>;
+    fn submit_connect_named_pipe(&self) -> Submission<()>;
+    fn deactivate(&self);
+    fn set_user_key(&self, key: usize);
+}
+
+enum Submission<B> {
+    Complete { bytes: usize, buf: B },
+    Pending(OpHandle<B>),
+    Failed { error: io::Error, buf: B },
+}
+
+impl<B> OpHandle<B> {
+    fn is_complete(&self) -> bool;
+    fn try_take(self) -> Result<(io::Result<usize>, B), Self>;
+    fn take(self) -> (io::Result<usize>, B);     // panics if not complete
+    fn cancel(&self) -> io::Result<()>;          // CancelIoEx
+}
+```
+
+`take` / `try_take` always return the buffer alongside the result so the
+caller can reclaim or drop it on either path. The shape mirrors
+`compio::BufResult<T, B>` (a tuple of `io::Result<T>` and `B`), which makes
+adapting these primitives into compio-style traits in downstream crates
+(e.g. `async-io`) straightforward. `cancel` takes `&self`; the buffer is
+recovered by the subsequent `take`/`try_take` call.
+
+`cancel` deliberately does **not** return `B`. `CancelIoEx` is asynchronous
+— it only *requests* cancellation, and the kernel may still be touching the
+buffer when `cancel` returns. The final completion packet (a late `Ok(n)`
+or `Err(ERROR_OPERATION_ABORTED)`) arrives on the IOCP some time later, and
+the buffer must stay pinned at its original address until that completion
+is observed; releasing `B` from `cancel` would risk a use-after-free. The
+caller therefore drives the same drain path on cancel as on normal
+completion: wait for `is_complete`, then `take`/`try_take` to recover `B`
+together with the final result. This matches `compio`'s cancellation
+contract.
+
+The `unsafe` on `register_file` mirrors the existing `Poller::add` and
+`add_waitable` contract: the caller is responsible for keeping the
+underlying handle alive until every `OpHandle` produced from this
+registration has been drained. `polling` never closes the handle.
+
+`PollMode` is implicitly **edge-triggered duplex** — every successful
+overlapped call produces exactly one completion, so there is no
+level/oneshot state machine to maintain.
+
+---
+
+## 2. Why not readiness?
+
+A readiness-style file API (returning `Event { readable, writable }`
+flags from `Poller::wait` and letting the user issue `ReadFile` /
+`WriteFile` afterwards) was the original shape on this branch and was
+discarded. Four issues made it untenable for IOCP file handles:
+
+### 2.1 Buffer lifetime
+
+A readiness API takes `&mut [u8]` at submit time. When `ReadFile`
+returns `ERROR_IO_PENDING`, the kernel keeps the buffer pointer until
+the operation completes — but the borrow on `&mut [u8]` ends as soon
+as the function returns. Nothing in the type system stops the caller
+from dropping, moving, or aliasing the buffer while the kernel is
+still writing into it. That is undefined behaviour.
+
+The `RegisteredFile::submit_*` API takes ownership of an
+`impl StableBuf{,Mut}` and returns it to the caller via
+`Submission::Complete { buf }` / `OpHandle::take() -> (usize, B)`, so
+the type system enforces that the buffer lives until the kernel is
+done with it.
+
+### 2.2 Concurrent ops
+
+A readiness API has one `OVERLAPPED` per direction per handle. Reusing
+a single `OVERLAPPED` for two simultaneous reads on the same handle is
+undefined behaviour on Windows: the kernel writes the status into the
+same block twice and the two completions become indistinguishable.
+
+Named pipes are full-duplex *and* often pipelined; HTTP/2-style
+servers and AFD-backed sockets routinely keep several reads queued
+behind a single handle. The 1-op-per-direction restriction made the
+readiness API unusable for those workloads.
+
+The completion API allocates a fresh `OpInner` per `submit_*` call,
+so any number of reads and writes can be in flight simultaneously
+without aliasing.
+
+### 2.3 Cancellation
+
+`CancelIoEx` is per-`(handle, OVERLAPPED)`. Without an op-scoped
+`OVERLAPPED`, a readiness API can only cancel *all* I/O on the handle,
+never a single read or write. And `CancelIoEx` followed by buffer drop
+is racy unless the buffer is owned until the completion is dequeued —
+which §2.1 already rules out.
+
+`OpHandle::cancel` calls `CancelIoEx` against that specific op's
+`OVERLAPPED`, leaving sibling ops on the same handle untouched.
+
+### 2.4 Sync fast path
+
+When a `ReadFile` / `WriteFile` returns `TRUE` synchronously, IOCP
+still posts a completion packet that the caller's `Poller::wait` must
+dequeue and discard. Windows lets us opt out of that by passing
+`FILE_SKIP_COMPLETION_PORT_ON_SUCCESS | FILE_SKIP_SET_EVENT_ON_HANDLE`
+to `SetFileCompletionNotificationModes`. `compio` sets these flags
+unconditionally; the readiness shape never set them and so paid the
+cost on every successful sync op.
+
+The current API sets both flags on `register_file` and surfaces sync
+success as `Submission::Complete { bytes, buf }` directly, with no
+IOCP packet to drain.
+
+---
+
+## 3. Architecture
+
+### 3.1 Type system
+
+```text
+┌──────────────────────────────────────────────────────────────────┐
+│ User code                                                        │
+│   let rf = unsafe { poller.register_file(handle, key)? };        │
+│   match rf.submit_read(vec![0u8; 4096]) {                        │
+│       Submission::Complete { bytes, buf } => …,                  │
+│       Submission::Pending(op)             => …,                  │
+│       Submission::Failed   { error, buf } => …,                  │
+│   }                                                              │
+└──────────────────────────────────────────────────────────────────┘
+                                  │
+                                  ▼
+┌──────────────────────────────────────────────────────────────────┐
+│ RegisteredFile  → Arc<RegisteredFileInner>                       │
+│   { handle, port, active: AtomicBool, user_key: AtomicUsize }    │
+└──────────────────────────────────────────────────────────────────┘
+                                  │ submit_*
+                                  ▼
+┌──────────────────────────────────────────────────────────────────┐
+│ OpHandle<B>     → Pin<Arc<IoStatusBlock<PacketInner::FileOp>>>   │
+│   PhantomData<B> tracks the user-supplied buffer type            │
+└──────────────────────────────────────────────────────────────────┘
+                                  │ kernel-Arc bumped on Pending
+                                  ▼
+┌──────────────────────────────────────────────────────────────────┐
+│ IoCompletionPort<Packet>                                         │
+│   high-bit-of-key classifier → file vs socket/waitable           │
+└──────────────────────────────────────────────────────────────────┘
+                                  │ GetQueuedCompletionStatusEx
+                                  ▼
+┌──────────────────────────────────────────────────────────────────┐
+│ Poller::wait_deadline                                            │
+│   reclaim Arc, publish bytes / nt_status / state, push Event     │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+`RegisteredFileInner` holds:
+
+- `handle: RawHandle` — borrowed; never closed by us. Used by
+  `CancelIoEx` and the submission helpers.
+- `port: Arc<IoCompletionPort<Packet>>` — keeps the IOCP alive at
+  least as long as any in-flight op needs to deliver a completion.
+- `active: AtomicBool` — flipped to `false` by
+  `RegisteredFile::deactivate`. Subsequent `submit_*` calls return
+  `Failed { error: InvalidInput, buf }`.
+- `user_key: AtomicUsize` — written by `set_user_key` (Release), read
+  by the dispatcher (Acquire). Mirrored into every `Event` this file
+  emits.
+
+`OpInner` is the kernel-visible per-op block:
+
+```rust
+#[repr(C)]
+pub(crate) struct OpInner {
+    overlapped: UnsafeCell<OVERLAPPED>,        // first field — kernel writes here
+    state: AtomicU8,                           // Submitted | Completed | Cancelled
+    bytes_transferred: AtomicU32,
+    nt_status: AtomicI32,
+    taken: AtomicBool,                         // OpHandle::take has consumed buf
+    buf_storage: UnsafeCell<MaybeUninit<ErasedBuf>>,
+    vtable: &'static OpVTable,                 // drop_buf for the actual B
+    file: Option<Arc<RegisteredFileInner>>,    // back-reference; Some(_) for submit_*-issued ops
+    interest: OpInterest,                      // direction this op cares about
+    _pinned: PhantomPinned,                    // kernel holds raw &overlapped
+}
+```
+
+The `OVERLAPPED` lives at offset 0, so `lpOverlapped` in the
+completion entry can be cast straight back to `*mut OpInner` after
+the file-op classifier has identified the entry. `OpInner` is plugged
+into the existing `Packet = Pin<Arc<IoStatusBlock<PacketInner>>>`
+dispatch type as a new variant `PacketInner::FileOp { #[pin] op: OpInner }`,
+so `IoCompletionPort::wait` and the rest of the dispatcher do not
+need to be generic over two unrelated packet types.
+
+`OpHandle<B>` is a thin `Pin<Arc<…>>` wrapper that remembers `B` only
+in the type system — the runtime type tag is `OpInner::vtable`,
+which knows how to `drop_in_place::<B>` the type-erased
+`buf_storage` slot.
+
+### 3.2 `StableBuf` / `StableBufMut`
+
+The buffer trait is deliberately minimal:
+
+```rust
+pub unsafe trait StableBuf: Send + 'static {
+    fn as_ptr(&self)  -> *const u8;
+    fn len(&self)     -> usize;
+}
+
+pub unsafe trait StableBufMut: StableBuf {
+    fn as_mut_ptr(&mut self) -> *mut u8;
+    fn capacity(&self)        -> usize;
+}
+```
+
+Blanket impls cover `Vec<u8>` and `Box<[u8]>` for the mutable side,
+plus `&'static [u8]` and `()` (for `submit_connect_named_pipe`) for
+the immutable side. Ownership is `'static` (no borrowed lifetimes) —
+the only way to enforce §2.1 in the type system. Crates that already
+do their own lifetime accounting are expected to wrap a raw region
+in their own `StableBuf` newtype and uphold the safety contract.
+
+The `OpInner::buf_storage` slot is dimensioned for buffer wrapper
+types up to 32 bytes / 8-byte aligned (concretely: a `Vec<u8>`'s
+`(ptr, len, cap)` triple, a `Box<[u8]>`'s `(ptr, len)` pair, etc.).
+Buffers exceeding the slot are rejected synchronously as
+`Submission::Failed { error: InvalidInput, buf }` — never UB.
+
+### 3.3 Submission classification
+
+Every `submit_*` call funnels through a classifier that maps the
+syscall result to one of three `Submission` variants:
+
+| Kernel return         | `Submission` variant                          | Kernel Arc bump? |
+|-----------------------|-----------------------------------------------|------------------|
+| `TRUE`                | `Complete { bytes, buf }` (sync fast path)    | no               |
+| `FALSE` + `ERROR_IO_PENDING` | `Pending(OpHandle<B>)`                 | **yes**          |
+| `FALSE` + other err   | `Failed { error, buf }`                       | no               |
+
+`submit_connect_named_pipe` adds a fourth case for the
+`ConnectNamedPipe` quirk: `FALSE + ERROR_PIPE_CONNECTED` (the client
+had already connected before the call) is treated as sync success.
+
+Sync-success and sync-failure both reclaim the buffer immediately
+via a raw `ptr::read` out of `buf_storage`, mark `taken = true`, and
+hand the buffer back to the caller. The packet is dropped at the end
+of the classifier; `OpInner::Drop` sees `taken == true` and skips the
+type-erased `vtable.drop_buf`.
+
+### 3.4 Kernel-Arc protocol (bump on Pending, reclaim in dispatcher)
+
+The single most important invariant in the file API:
+
+> Every `Pending` submission bumps the packet's `Arc` strong count
+> by exactly one (via `mem::forget(packet.clone())`). The IOCP
+> completion dispatcher reclaims that bump exactly once, via
+> `Arc::from_raw` inside `OverlappedEntry::into_file_op_packet`. Sync
+> success and sync failure must NOT bump — they leave the Arc
+> reference balanced.
+
+`FILE_SKIP_COMPLETION_PORT_ON_SUCCESS` (set in `register_file`)
+guarantees that sync success will not produce an IOCP entry, so there
+is no completion path that could spuriously reclaim.
+
+The bump/reclaim pairing means:
+
+- A `Pending` `OpHandle` may be dropped immediately. The kernel still
+  holds one strong reference, so the buffer stays alive at the
+  registered address. When the completion eventually arrives, the
+  dispatcher reclaims the kernel's Arc, drops the last reference, and
+  `OpInner::Drop` runs the `vtable.drop_buf` to release the buffer.
+  No use-after-free, no leak — but no way to recover the buffer
+  either.
+- If the completion arrives *after* `OpHandle::take`, the dispatcher's
+  `Arc::from_raw` decrements the count to zero (the user handle is
+  already gone). `OpInner::Drop` sees `taken == true` and skips the
+  buffer destructor.
+
+### 3.5 Cancellation
+
+`OpHandle::cancel(&self)` is best-effort:
+
+1. If `state == Completed` already, return `Ok(())`.
+2. CAS `state: Submitted → Cancelled` (no-op if already cancelled).
+3. Issue `CancelIoEx(file.handle, &op.overlapped)`. `ERROR_NOT_FOUND`
+   is treated as `Ok(())` (the kernel had already completed or
+   delivered the op).
+
+`Cancelled` is a hint for tracing; it is **not** load-bearing.
+Whether the op was racing the kernel or already in flight, the
+kernel will eventually post one completion entry (typically with
+`STATUS_CANCELLED`). The dispatcher unconditionally publishes
+`Completed` and lets the `nt_status` field encode the outcome —
+`OpHandle::take` then surfaces `Err(ERROR_OPERATION_ABORTED)`.
+
+### 3.6 Sync fast path
+
+`register_file` calls `IoCompletionPort::register` with the flag set
+
+```text
+FILE_SKIP_SET_EVENT_ON_HANDLE | FILE_SKIP_COMPLETION_PORT_ON_SUCCESS
+```
+
+`ERROR_INVALID_FUNCTION` (the device does not support the modes) is
+treated as a non-fatal no-op. Successful sync ops therefore never
+produce an IOCP packet, and `Submission::Complete` is the
+zero-syscall-after-submit path.
+
+### 3.7 Deactivation and the drain dance
+
+`RegisteredFile::deactivate` flips the `active` flag to `false` and
+returns immediately. Three invariants govern the surrounding state:
+
+1. The kernel must never write into a freed `OVERLAPPED`.
+2. The user must always be able to recover their buffers eventually.
+3. After `deactivate`, no *new* ops may be submitted.
+
+What `deactivate` does:
+
+- Subsequent `submit_*` calls return
+  `Submission::Failed { error: InvalidInput, .. }`.
+- **No `CancelIoEx` is issued automatically.** The caller may have
+  legitimate in-flight ops they want to keep running.
+- The user's `HANDLE` is not closed; `polling` never owned it.
+- In-flight `OpHandle<B>`s keep working. Each holds a kernel-bumped
+  `Arc<Packet>` that transitively keeps the `IoCompletionPort` alive,
+  so the eventual completion still has a live destination. The user
+  must continue calling `Poller::wait` until every outstanding op has
+  drained.
+
+For "I want to abort *now*" the caller does the explicit dance:
+
+```rust
+rf.deactivate();                             // stop accepting new ops
+for op in &in_flight {
+    let _ = op.cancel();                     // CancelIoEx per op
+}
+while !in_flight.is_empty() {
+    poller.wait(&mut events, None)?;
+    for ev in events.iter() {
+        if let Some(op) = in_flight.take_matching(ev.key) {
+            // Result will typically be Err(ERROR_OPERATION_ABORTED).
+            let _ = op.take();
+        }
+    }
+}
+// Now safe to drop / close the HANDLE.
+drop(handle);
+```
+
+This dance is the same one Mio, tokio-uring, and compio require.
+`polling` does not try to hide it inside `deactivate` because the set
+of in-flight ops is owned by the user (not by the poller, which
+cannot iterate them) and a blocking "wait until drained" inside
+`deactivate` would invert control flow and break callers that share
+the poller across threads.
+
+**Misuse — dropping a pending `OpHandle`:** safe and silent. The
+kernel still holds one strong ref via the bump in §3.4, so the
+`OpInner` allocation (and the buffer it owns) survive until the
+completion arrives. The dispatcher's `Arc::from_raw` then drops the
+last reference, `OpInner::Drop` runs `vtable.drop_buf`, and the
+buffer is released. Sound, but the buffer is unrecoverable — the
+future-cancellation pattern is `op.cancel()` followed by `op.take()`
+after the completion is observed.
+
+---
+
+## 4. Completion delivery
+
+### 4.1 Dispatcher write order (load-bearing)
+
+For each FileOp completion entry pulled from
+`GetQueuedCompletionStatusEx`, the dispatcher in
+`Poller::wait_deadline` does:
+
+```text
+1. let packet = entry.into_file_op_packet();    // Arc::from_raw — reclaim kernel ref
+2. op.bytes_transferred.store(entry.dwNumberOfBytesTransferred, Release)
+3. op.nt_status.store(entry.nt_status_raw(),                     Release)
+4. op.state.store(OpState::Completed as u8,                      Release)
+5. let interest = op.interest;
+6. let key      = op.file.as_ref().unwrap().user_key.load(Acquire);
+7. events.packets.push(Event { key, readable: interest.readable, writable: interest.writable, .. })
+8. drop(packet);                                // last Arc — runs OpInner::Drop if user already dropped OpHandle
+```
+
+Step 4 must release-store **before** step 7 pushes the event, so the
+Acquire-load on `state` performed by `OpHandle::is_complete()` (which
+the woken future will call after its reactor wakes it) sees
+`Completed`. Re-ordering 4 and 7 would allow the woken task to
+observe a stale `Submitted` and re-park, losing the wake.
+
+### 4.2 `OpInterest` and event direction
+
+`OpInterest { readable, writable }` is set once per op at submit time
+and read once by the dispatcher when constructing the event:
+
+| `submit_*`                  | `event.readable` | `event.writable` |
+|-----------------------------|------------------|------------------|
+| `submit_read`               | `true`           | `false`          |
+| `submit_write`              | `false`          | `true`           |
+| `submit_connect_named_pipe` | `true`           | `false`          |
+
+Connect maps to readable-only because the typical pattern is "server
+submits `connect`, then submits `read` once a client is attached" —
+wakers parked on the readable direction are the natural audience.
+
+### 4.3 `set_user_key` contract
+
+`RegisteredFile::set_user_key(key)` rebinds the user-visible event
+key for all *future* completions emitted by this file. Reactors that
+allocate the event key after constructing the `RegisteredFile` (e.g.
+[`async-io`](https://docs.rs/async-io)'s `Slab<Source>` indexing —
+see §5) call `set_user_key` once with the slab slot's index.
+
+The store is `Release`; the dispatcher's load is `Acquire`. A
+`set_user_key` racing with the dispatcher either lands before the
+load (event carries the new key) or after it (event carries the old
+key). Both outcomes are documented as acceptable — `set_user_key` is
+best-effort for in-flight ops and exact for ops submitted after the
+call returns.
+
+---
+
+## 5. Async-io integration
+
+### 5.1 Why Shape A (key per `RegisteredFile`)
+
+Three shapes were considered for how a readiness-style reactor learns
+about file-op completions:
+
+| Shape | Key granularity        | Waker storage              | Layering |
+|-------|------------------------|----------------------------|----------|
+| A     | one per `RegisteredFile` | reactor's existing `Source` | clean    |
+| B     | one per `OpHandle`       | per-file `Slab<Waker>`      | leaky    |
+| C     | none                   | `AtomicWaker` on `OpInner` | broken — `polling` would have to call `Waker::wake` itself |
+
+Shape A is what we ship, for three reasons:
+
+- **Same convention as sockets / waitables.** `register_file(handle, key)`
+  mirrors `Poller::add(socket, Event::none(key))`. The reactor's
+  `Slab<Source>` indexes the key the same way for every kind of
+  source.
+- **Zero new mutexes inside `polling`.** `OpInner` is lock-free;
+  `RegisteredFileInner` only adds an `AtomicBool` and an `AtomicUsize`.
+- **Reactor never sees `OpHandle`.** `OpHandle` is the user's
+  per-future state; the reactor only reacts to "something happened
+  on this key" and wakes the bound wakers.
+
+### 5.2 Proposed `Registration::File` variant
+
+In `async-io`'s `Registration` enum (`src/reactor/windows.rs`):
+
+```rust
+pub enum Registration {
+    Socket(RawSocket),
+    Handle(RawHandle),                        // existing waitable
+    File(Arc<polling::RegisteredFile>),       // NEW
+}
+
+impl Registration {
+    fn add(&self, poller: &Poller, key: usize) -> io::Result<()> {
+        match self {
+            Self::File(rf) => { rf.set_user_key(key); Ok(()) }
+            // … existing Socket / Handle arms unchanged
+        }
+    }
+    fn modify(&self, poller: &Poller, _interest: Event) -> io::Result<()> {
+        match self {
+            // File ops carry their own per-op interest; no modify needed.
+            Self::File(_) => Ok(()),
+            // … existing Socket / Handle arms unchanged
+        }
+    }
+    fn delete(&self, poller: &Poller) -> io::Result<()> {
+        match self {
+            Self::File(rf) => { rf.deactivate(); Ok(()) }
+            // … existing Socket / Handle arms unchanged
+        }
+    }
+}
+```
+
+The variant carries `Arc<RegisteredFile>` (not `RawHandle`) because
+`RegisteredFile` is the only legal way to submit ops on the handle,
+and the handle is registered with the IOCP at construction time —
+the reactor must not re-register or it would collide with the
+existing kernel binding.
+
+### 5.3 `Async<NamedPipe>` sketch
+
+```rust
+pub struct AsyncNamedPipe {
+    source: Arc<Source>,                      // async-io's Source
+    file:   Arc<polling::RegisteredFile>,
+}
+
+impl AsyncNamedPipe {
+    pub async fn read(&self, buf: Vec<u8>) -> io::Result<(usize, Vec<u8>)> {
+        match self.file.submit_read(buf) {
+            Submission::Complete { bytes, buf }   => Ok((bytes, buf)),
+            Submission::Failed   { error, buf: _ } => Err(error),
+            Submission::Pending(handle) => ReadFut { handle: Some(handle), source: &self.source }.await,
+        }
+    }
+}
+
+struct ReadFut<'a, B> { handle: Option<OpHandle<B>>, source: &'a Arc<Source> }
+
+impl<'a, B: Unpin> Future for ReadFut<'a, B> {
+    type Output = io::Result<(usize, B)>;
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let h = self.handle.as_ref().unwrap();
+        if h.is_complete() {
+            return Poll::Ready(self.handle.take().unwrap().take());
+        }
+        ready!(self.source.poll_readable(cx))?;
+        if h.is_complete() {
+            return Poll::Ready(self.handle.take().unwrap().take());
+        }
+        Poll::Pending
+    }
+}
+```
+
+The future owns its `OpHandle` exclusively; cancel-on-drop is
+available via `handle.cancel()` in a `Drop` impl. `source.poll_readable(cx)`
+is the *same* method `Async<TcpStream>` uses — no new reactor surface.
+
+### 5.4 Spurious wake budget
+
+A `RegisteredFile` can have any number of in-flight `OpHandle`s of
+either direction. When *any* one of them completes, every waker bound
+to the file's key in the matching direction is woken. Each woken
+future then:
+
+1. Calls `OpHandle::is_complete()` on its own handle (one Acquire load).
+2. If `false`: re-registers its waker and returns `Poll::Pending`.
+3. If `true`: calls `OpHandle::take()` and returns `Poll::Ready`.
+
+Cost per completion: O(in-flight ops on this file in this direction).
+This matches edge-triggered epoll semantics. For pathological
+multi-op-per-file workloads, a future revision could add a per-file
+`Slab<Waker>` keyed by `Arc<OpInner>` identity inside `async-io`,
+but this is **not** part of the v1 contract.
+
+---
+
+## 6. Cross-platform considerations (io_uring)
+
+The shape is deliberately such that a Linux io_uring backend can live
+behind the same public types:
+
+| Concept              | IOCP                              | io_uring                            |
+| -------------------- | --------------------------------- | ----------------------------------- |
+| `RegisteredFile`     | handle + IOCP attach + flags      | fd (no per-fd state needed)         |
+| `OpInner`            | `OVERLAPPED` + buf + state        | `user_data` ptr to buf + state      |
+| `submit_read`        | `ReadFile(.., &op.overlapped)`    | sqe `IORING_OP_READ`                |
+| `Submission` variant | `TRUE` / `IO_PENDING` / err       | always `Pending` (or sqe-full err)  |
+| `cancel`             | `CancelIoEx`                      | `IORING_OP_ASYNC_CANCEL`            |
+| completion delivery  | `OVERLAPPED_ENTRY.lpOverlapped`   | `cqe.user_data`                     |
+
+The only API-visible difference is that io_uring has no native
+sync-success short-cut — `Submission::Complete` would simply never
+be produced on Linux, only `Pending`. Quality-of-implementation
+difference, not an API difference.
+
+`StableBuf` / `StableBufMut` are exactly what io_uring requires
+(the kernel polls memory at the registered address while the sqe is
+in flight), so no extra abstraction layer is needed.
+
+---
+
+## 7. Test coverage
+
+| Test file | Coverage |
+|-----------|----------|
+| [tests/windows_overlapped.rs](../tests/windows_overlapped.rs) | Happy-path round-trips, single-op semantics, `register_file` collisions, drop ordering. |
+| [tests/file_concurrent.rs](../tests/file_concurrent.rs) | Multiple concurrent reads / writes, mixed read+write, per-op cancellation. |
+| [tests/file_lifetime.rs](../tests/file_lifetime.rs) | `OpHandle` outliving `RegisteredFile`, `OpHandle` outliving `Poller`, `deactivate` semantics, in-flight ops across deactivation. |
+| [tests/common/mod.rs](../tests/common/mod.rs) | Shared helpers: `new_named_pipe`, `server`, `client`, `pipe`, Wine-skip predicate, generous `wait_for_event` polling. |
+
+Build / test gates (run by CI and on every commit on this branch):
+
+```pwsh
+cargo check --target x86_64-pc-windows-msvc --tests --examples
+cargo test  --target x86_64-pc-windows-msvc
+$env:RUSTDOCFLAGS="-D warnings"; cargo doc --no-deps --target x86_64-pc-windows-msvc
+```
+
+---
+
+## 8. Open questions
+
+1. **`Submission` ergonomics.** Three variants is the right shape for
+   the kernel's actual outcomes, but most callers only branch on
+   `Pending` vs not. A `Result<Either<…>, …>` or a small helper like
+   `Submission::into_pending(self) -> io::Result<Option<OpHandle<B>>>`
+   may read better in `async` glue code.
+2. **Multishot reads.** io_uring supports `IORING_OP_RECV` in
+   multishot mode (one submission, many completions). IOCP has no
+   equivalent. Out of scope for v1.
+3. **Scatter/gather (`ReadFileScatter` / `WriteFileGather`).** Likely
+   v2; the buffer trait would gain `as_iovec` / `as_iovec_mut`.
+4. **Buffer pools / registered buffers
+   (`IORING_REGISTER_BUFFERS`, `RIO_*`).** Out of scope for v1.
+5. **`async-io` cancel-on-drop policy.** `polling` defaults to
+   "silent drop = leak the `OpHandle` but keep the kernel Arc; buffer
+   is reclaimed on completion." Whether `async-io`'s per-op future
+   should call `handle.cancel()` on drop to bound the in-flight
+   buffer count is an open item for the follow-up `async-io` PR.
+
+### 8.1 Out of scope
+
+Deliberately not addressed in v1, in addition to the items above:
+
+- Async/await wrappers around `OpHandle`. Downstream crates do this.
+- Buffer pools / registered buffers (`IORING_REGISTER_BUFFERS`,
+  `RIO_*` for sockets).
+- AFD socket completions (already supported by `polling` separately).
+- Replacing the readiness side of `polling` — this design only
+  changes the file-handle corner.

--- a/docs/named-pipe.implement.checklist.md
+++ b/docs/named-pipe.implement.checklist.md
@@ -1,0 +1,325 @@
+# Named-Pipe Redesign — Implementation Checklist
+
+Tracks step-by-step implementation of the design described in
+[`named-pipe.design.md`](./named-pipe.design.md). Each item maps
+back to a section in that doc. Mark items `[x]` as they land.
+
+Build/test gate between every step:
+
+```pwsh
+cargo check
+cargo test
+$env:RUSTDOCFLAGS="-D warnings"; cargo doc --no-deps
+```
+
+---
+
+## Step 1 — Internal: replace `FileFields` with `OpInner` (no public API change)
+
+Goal: introduce the per-op kernel-visible block alongside the existing
+file path. Old API still compiles.
+
+- [x] 1.1 Add `OpInner` struct in `src/iocp/mod.rs`:
+  - [x] `#[repr(C)]`, `OVERLAPPED` at offset 0
+  - [x] `state: AtomicU8` (`Submitted | Completed | Cancelled`)
+  - [x] `bytes_transferred: AtomicU32`
+  - [x] type-erased buffer slot (`UnsafeCell<MaybeUninit<ErasedBuf>>`)
+  - [x] `vtable: &'static OpVTable` (`drop_buf`, `take_buf`)
+  - [ ] `file: Arc<RegisteredFile>` back-reference (forward decl ok) — *deferred to Step 2 (RegisteredFile not yet defined)*
+- [x] 1.2 Add `PacketInner::FileOp { #[pin] op: OpInner }` variant
+  alongside existing `PacketInner::File`.
+- [x] 1.3 Extend `wait_deadline` completion loop: `is_file_completion()`
+  routes to either `File` (old) or `FileOp` (new) without breaking
+  socket / waitable / custom paths.
+- [x] 1.4 Unit-test the vtable: construct an `OpInner` for `Vec<u8>`,
+  drop it, ensure no leak (Miri). *(3 tests in `iocp::op_tests`)*
+- [x] 1.5 `cargo test` — existing `tests/windows_overlapped.rs` still
+  green.
+
+---
+
+## Step 2 — New submission API behind a feature flag
+
+ Submission::Pending(handle) k Submission::Pending(handle)
+> **Refined by Step 7** — items 2.9–2.11 below describe the original
+> `FileCompletion` token + `Events::iter_file_completions` channel.
+> That design was replaced by `OpHandle::{is_complete, try_take, take,
+> register_waker}`. See Step 7 for the final shape.
+
+Goal: ship `RegisteredFile` / `OpHandle<B>` / `Submission<B>` in
+parallel with the old API. Gate behind `#[doc(hidden)]` or
+`feature = "iocp-file-v2"`.
+
+- [x] 2.1 Add `StableBuf` / `StableBufMut` traits (minimal surface,
+  `# Safety` doc per §3.2). *(in `src/iocp/buf.rs`)*
+  - [x] Blanket impls: `Vec<u8>`, `Box<[u8]>`, `&'static [u8]`
+  - [ ] (Optional) `bytes::Bytes` / `BytesMut` behind a `bytes` feature — *deferred; not required for v1*
+- [x] 2.2 Add `RegisteredFile` (Clone, Arc-backed):
+  - [x] `handle: RawHandle`, `port: Arc<IoCompletionPort<…>>`,
+    `active: AtomicBool` *(in `RegisteredFileInner`)*
+  - [x] Internal ctor invoked from `Poller::register_file`
+    (separate from legacy `add_file` per design)
+- [x] 2.3 Add `OpHandle<B>` typed wrapper over
+  `Pin<Arc<IoStatusBlock<PacketInner>>>` + `PhantomData<B>`.
+- [x] 2.4 Add `Submission<B>` enum: `Complete { bytes, buf } |
+  Pending(OpHandle<B>) | Failed { error, buf }`.
+- [x] 2.5 Implement `RegisteredFile::submit_read<B: StableBufMut>`:
+  - [x] Allocate `Pin<Arc<IoStatusBlock<PacketInner::FileOp>>>`
+  - [x] Stash buffer via vtable
+  - [x] Call `ReadFile`, classify return into the three variants
+  - [x] On failure path, reclaim Arc and return buffer
+- [x] 2.6 Implement `RegisteredFile::submit_write<B: StableBuf>`
+  (symmetric).
+- [x] 2.7 Implement `RegisteredFile::submit_connect_named_pipe()
+  -> Submission<()>`.
+- [x] 2.8 Implement `OpHandle::cancel(&self) -> io::Result<()>`
+  (`CancelIoEx(handle, &op.overlapped)`).
+- [x] 2.9 Implement `OpHandle::take` *via* `FileCompletion` (see 2.11):
+  vtable extracts buffer, returns `(usize, B)` or `io::Error`.
+- [x] 2.10 Implement "leak buffer on premature drop" rule
+  (§6a.3 *Misuse*): `OpHandle::Drop` leaks the packet `Arc` when
+  `state != Completed`.
+- [x] 2.11 Add `FileCompletion<'a>` token + `Events::iter_file_completions`.
+  Existing `Events::iter()` continues to skip file completions.
+- [x] 2.12 Wire `register_file` to call
+  `SetFileCompletionNotificationModes(handle,
+  FILE_SKIP_COMPLETION_PORT_ON_SUCCESS | FILE_SKIP_SET_EVENT_ON_HANDLE)`.
+  Tolerate `ERROR_INVALID_FUNCTION`. *(legacy `add_file` does NOT set
+  these flags — it would break tests that depend on sync-success
+  completions arriving)*
+- [x] 2.13 Wire sync-success branch in `submit_*` to return
+  `Submission::Complete` (the IOCP packet is suppressed by 2.12).
+- [x] 2.14 `cargo doc --no-deps -D warnings` clean for new public items
+  (with and without `--features iocp-file-v2`).
+
+---
+
+## Step 3 — Tests for the new API
+
+> **Refined by Step 7** — tests originally written against
+> `FileCompletion` / `Events::drain_file_completions` were rewritten to
+> drive `OpHandle::is_complete` + `OpHandle::take`.
+
+- [x] 3.1 Create `tests/common/mod.rs` with named-pipe helpers
+  (`new_named_pipe`, `server`, `client`, `pipe`) extracted from
+  `windows_overlapped.rs`.
+- [x] 3.2 Create `tests/file_concurrent.rs`:
+  - [x] `two_concurrent_writes_distinguish_completions`
+  - [x] `two_concurrent_reads_dispatch_correctly`
+  - [x] `mixed_read_write_concurrent`
+  - [x] `cancel_pending_read_returns_aborted`
+  - [x] `cancel_after_completion_is_noop`
+  - [x] `cancel_one_of_many_does_not_affect_siblings`
+  - [x] `sync_success_returns_complete_variant`
+  - [x] `async_path_still_returns_pending`
+- [x] 3.3 Create `tests/file_lifetime.rs`:
+  - [x] `op_outlives_registered_file_clone`
+  - [~] `submit_after_remove_file_errors` — mapped to
+    `RegisteredFile::deactivate()` (v2 has no `remove_file`).
+  - [~] `in_flight_op_completes_after_remove_file` — mapped to
+    `RegisteredFile::deactivate()` (v2 has no `remove_file`).
+  - [x] `poller_dropped_before_op_completion`
+  - [~] 3.3 `drop_pending_op_does_not_uaf` — Miri-only stub; the v2
+    submit path is unconditional Win32 syscalls (`ReadFile` /
+    `CancelIoEx`) which Miri cannot evaluate, so a meaningful
+    Miri-friendly variant is blocked without a `#[cfg(test)]`
+    constructor for `OpInner`. Non-Miri equivalent is
+    `poller_dropped_before_op_completion`.
+  - [x] `buf_addr_stable_across_submit`
+  - [~] `vec_grown_after_submit_is_safe` — runtime variant impossible
+    because the v2 API takes the buffer by value (caller has no
+    handle to the `Vec` between `submit_*` and `take`); recorded as
+    a `compile_fail`-style note in the test file.
+- [x] 3.4 `#[ignore]` stress test `many_ops_stress` (10 000 ops).
+- [x] 3.5 `cargo test --features iocp-file-v2 --target x86_64-pc-windows-msvc`
+  green; `RUSTDOCFLAGS=-D warnings cargo doc --no-deps
+  --target x86_64-pc-windows-msvc` green (with and without the
+  feature). Miri opt-in deferred to user.
+
+---
+
+## Step 4 — Port the existing test suite
+
+> **Refined by Step 7** — `submit_*` + `FileCompletion::take` rewritten
+> as `submit_*` + `OpHandle::take`.
+
+Translate `tests/windows_overlapped.rs` per §8.1 disposition table.
+
+- [x] 4.1 `win32_file_io` → `submit_write` + `FileCompletion::take`
+- [x] 4.2 `writable_after_register`
+- [x] 4.3 `write_then_read`
+- [x] 4.4 `close_before_read_complete`
+- [x] 4.5 `close_before_write_twice_complete` → folded into
+  `two_concurrent_writes_distinguish_completions`
+- [x] 4.6 `connect_before_client`
+- [x] 4.7 `write_disconnected`
+- [x] 4.8 `write_then_drop` → replaced by `drop_writer_drain`
+  (assertions on `test_ref_count` removed)
+- [x] 4.9 `connect_twice`
+- [x] 4.10 `remove_file_before_add_file`
+- [x] 4.11 `add_file_different_poll`
+- [x] 4.12 Inline helper copies removed; `mod common;` used instead.
+
+---
+
+## Step 5 — Remove the old API
+
+- [x] 5.1 Delete `IocpFilePacket` (struct + impls).
+- [x] 5.2 Delete `FileOverlappedConverter`, `FileOverlappedWrapper`.
+- [x] 5.3 Delete `Overlapped<T>` newtype (logic absorbed by `OpInner`).
+- [x] 5.4 Delete `read_file_overlapped`, `write_file_overlapped`,
+  `connect_named_pipe_overlapped`.
+- [x] 5.5 Delete `file_op_overlapped` helper.
+- [x] 5.6 Delete `PacketInner::File` variant + `FileFields`.
+- [x] 5.7 Delete `IocpFilePacket::test_ref_count` references.
+- [x] 5.8 Drop the feature gate / `#[doc(hidden)]` from step 2 — new
+  types become the stable surface.
+- [x] 5.9 Update `examples/named_pipe.rs` to the new shape.
+- [x] 5.10 Add `examples/named_pipe_concurrent.rs` (two reads + cancel).
+- [x] 5.11 Add "Superseded by `named-pipe.design.md`" banner to
+  obsolete §2.x items in `docs/named-pipe.design.md`.
+- [x] 5.12 Update `CHANGELOG.md`.
+
+---
+
+## Step 6 — PR description & changelog
+
+- [ ] 6.1 Rebase commits onto current `kail/windows_file`.
+- [ ] 6.2 Update PR #248 description: link to
+  `docs/named-pipe.design.md`, call out the breaking change vs the
+  prior unreleased shape.
+- [ ] 6.3 Final CI green: `cargo test`, `cargo doc -D warnings`, Miri
+  opt-in tests.
+
+---
+
+## Step 7 — Refactor: drop `FileCompletion`, `OpHandle` owns completion
+
+Goal: collapse the two-step `OpHandle` → `FileCompletion` handoff into
+`OpHandle` itself, and fix the latent kernel-Arc-bump bug that forced
+`OpHandle::Drop` to leak via `ManuallyDrop`.
+
+- [x] 7.1 Add an `atomic_waker::AtomicWaker` field to `OpInner` and
+  initialize it in both constructors. (Used `atomic-waker = "1.1"` —
+  `futures-core` does not contain `AtomicWaker`.)
+- [x] 7.2 Bump the `Packet` strong count via `mem::forget(packet.clone())`
+  on the `ERROR_IO_PENDING` branches of `classify_submission` and
+  `submit_connect_named_pipe`. Document as the kernel's owned strong ref.
+- [x] 7.3 Switch `Pin<Arc<T>>::file_op_done` from
+  `Arc::increment_strong_count` (clone) to plain `Arc::from_raw`
+  (reclaim). Update `OverlappedEntry::Drop` to reclaim file completions
+  symmetrically.
+- [x] 7.4 In the dispatcher (`Poller::wait_deadline` file-completion
+  branch): stash `(bytes, nt_status)` on the op, unconditionally
+  publish `OpState::Completed` (cancellation outcome lives in
+  `nt_status`). *(Step 7b: now also pushes an `Event` instead of
+  waking a per-op `Waker` — see Step 7b.5.)*
+- [x] 7.5 Add `OpHandle` methods: `is_complete`, `try_take`, `take`
+  (panic on incomplete), `register_waker`. *(Step 7b removed
+  `register_waker` — see Step 7b.2.)*
+- [x] 7.6 Remove the custom `impl<B> Drop for OpHandle<B>` —
+  default `Pin<Arc<...>>` drop is now correct because the kernel owns
+  one strong ref until the dispatcher reclaims it.
+- [x] 7.7 Delete `FileCompletion<'a>`, `Events::file_completions`,
+  `Events::iter_file_completions`, `Events::drain_file_completions`.
+- [x] 7.8 Rewrite `tests/windows_overlapped.rs`,
+  `tests/file_concurrent.rs`, `tests/file_lifetime.rs`,
+  `examples/named_pipe.rs`, and `examples/named_pipe_concurrent.rs`
+  against the new surface.
+- [x] 7.9 Update `docs/named-pipe.design.md` (Step 7 amendment
+  banner) and this checklist (Step 7 section + Step 2/3/4 banners).
+- [x] 7.10 Gates green: `cargo check --target x86_64-pc-windows-msvc
+  --tests --examples`, `cargo test --target x86_64-pc-windows-msvc`,
+  `RUSTDOCFLAGS=-D warnings cargo doc --no-deps
+  --target x86_64-pc-windows-msvc`.
+
+## Step 7b — Replace waker with event emission (corrects Step 7)
+
+The first Step 7 implementation added `AtomicWaker` to `OpInner` and
+`OpHandle::register_waker(&Waker)`. That broke layering: `polling` is
+the *event* layer; the reactor (e.g. `async-io`'s `ReactorLock::react`
+in `D:\rust\async-io\src\reactor.rs`) owns the per-source waker
+registry keyed by `Event::key`. Step 7b deletes the waker layer and
+emits a normal `Event` per file-op completion instead.
+
+- [x] 7b.1 Remove `waker: atomic_waker::AtomicWaker` field from
+  `OpInner` and its initialisation in both `OpInner::new` and
+  `make_op_packet`. Drop the `atomic-waker` dependency from
+  `Cargo.toml`. Remove the `use std::task::Waker` from `mod v2`.
+- [x] 7b.2 Remove `OpHandle::register_waker(&Waker)` and its docs.
+  Update `OpHandle::take` panic message to point users at draining
+  `Poller::wait` rather than at `register_waker`.
+- [x] 7b.3 Add `user_key: usize` to `RegisteredFileInner`; thread it
+  through `Poller::register_file(handle, key)` and the public
+  `PollerIocpFileExt::register_file(file, key)` extension method.
+- [x] 7b.4 Add `OpInterest { readable, writable }` to `OpInner`; wire
+  `make_op_packet` to accept it. `submit_read` →
+  `(readable: true, writable: false)`; `submit_write` →
+  `(readable: false, writable: true)`; `submit_connect_named_pipe` →
+  `(readable: true, writable: false)` (server connect typically
+  precedes a read).
+- [x] 7b.5 Update the `Poller::wait_deadline` file-op completion arm
+  to perform the 5 stores in this order: bytes_transferred → nt_status
+  → state → push `Event { key, readable, writable, .. }` → drop the
+  kernel-bumped `Arc`. The `state` Release MUST precede the event push.
+- [x] 7b.6 Update `tests/windows_overlapped.rs`,
+  `tests/file_concurrent.rs`, `tests/file_lifetime.rs`,
+  `examples/named_pipe.rs`, `examples/named_pipe_concurrent.rs`: every
+  `register_file` call now passes a small distinct `usize` key.
+- [x] 7b.7 Add a tighter test that asserts `events.iter()` contains an
+  `Event { key, readable, writable }` matching the op's direction
+  (`tests/windows_overlapped.rs::read_completion_emits_event_with_key_and_direction`).
+- [x] 7b.8 Update `docs/named-pipe.design.md` Step 7 banner and add a
+  Step 7b banner documenting: the layering rationale, the dispatcher
+  store order, the `OpInterest` field, that connect = readable-only,
+  and that spurious wakes are bounded by in-flight ops on the same
+  file in the same direction.
+- [x] 7b.9 Gates green: `cargo check --target x86_64-pc-windows-msvc
+  --tests --examples`, `cargo test --target x86_64-pc-windows-msvc`,
+  `RUSTDOCFLAGS=-D warnings cargo doc --no-deps
+  --target x86_64-pc-windows-msvc`.
+
+---
+
+## Step 7c — Reactor-friendly key rebinding (`set_user_key`)
+
+Required by the async-io integration described in
+[`named-pipe.design.md`](./named-pipe.design.md) §5.2: a reactor
+that allocates the key from a `Slab` only knows the key *after*
+constructing the `RegisteredFile`. Today `register_file(handle, key)`
+forces the caller to commit to the key up-front, which means the
+reactor would need to either (a) construct `RegisteredFile` lazily on
+first use or (b) use a placeholder key and rebind. Option (b) is
+strictly cheaper and safer.
+
+- [x] 7c.1 Change `RegisteredFileInner.user_key: usize` to
+  `AtomicUsize`. Initialize from the value passed to
+  `register_file`.
+- [x] 7c.2 Replace the dispatcher's `op.file.user_key` read with an
+  `Acquire` load on the `AtomicUsize`. Verify the existing release
+  fence on `state.store(Completed, Release)` still happens-before the
+  user observing the event (it does — the event push reads `user_key`
+  *after* the state store).
+- [x] 7c.3 Add `pub fn RegisteredFile::set_user_key(&self, key: usize)`
+  that does a `Release` store. Document: "Intended for reactors that
+  allocate the event key after constructing the `RegisteredFile`. Has
+  no effect on completions already enqueued by the kernel."
+- [x] 7c.4 Add a unit / integration test
+  (`tests/file_concurrent.rs::set_user_key_takes_effect`):
+  register with key=0, submit a read, before peer writes call
+  `set_user_key(KEY)`, peer writes, assert the emitted `Event::key ==
+  KEY`.
+- [x] 7c.5 Update `docs/named-pipe.design.md` §5.2 to drop the
+  "TODO" framing on `set_user_key` and link to the implementation.
+- [x] 7c.6 Gates green: `cargo check --target x86_64-pc-windows-msvc
+  --tests --examples`, `cargo test --target x86_64-pc-windows-msvc`,
+  `$env:RUSTDOCFLAGS="-D warnings"; cargo doc --no-deps --target x86_64-pc-windows-msvc`.
+
+---
+
+## Cross-cutting verification (run after every step)
+
+- [ ] `cargo check`
+- [ ] `cargo test`
+- [ ] `$env:RUSTDOCFLAGS="-D warnings"; cargo doc --no-deps`
+- [ ] (After Steps 3 & 4) `cargo +nightly miri test --target x86_64-pc-windows-msvc`

--- a/examples/named_pipe.rs
+++ b/examples/named_pipe.rs
@@ -1,0 +1,129 @@
+//! Round-trip a small message through a Windows named pipe using the
+//! IOCP file-handle support of `polling` (v2 API).
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo run --example named_pipe
+//! ```
+//!
+//! On non-Windows targets this example is a no-op `main`.
+
+#[cfg(not(windows))]
+fn main() {
+    eprintln!("named_pipe example only runs on Windows");
+}
+
+#[cfg(windows)]
+fn main() -> std::io::Result<()> {
+    use polling::os::iocp::{OpHandle, PollerIocpFileExt, Submission};
+    use polling::{Events, Poller};
+
+    use std::ffi::OsStr;
+    use std::fs::OpenOptions;
+    use std::io;
+    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::fs::OpenOptionsExt;
+    use std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, OwnedHandle};
+    use std::time::Duration;
+
+    use windows_sys::Win32::{Foundation as wf, Storage::FileSystem as wfs, System::Pipes as wps};
+
+    fn server(name: &str) -> io::Result<OwnedHandle> {
+        let wide: Vec<u16> = OsStr::new(name).encode_wide().chain(Some(0)).collect();
+        let raw = unsafe {
+            wps::CreateNamedPipeW(
+                wide.as_ptr(),
+                wfs::PIPE_ACCESS_DUPLEX | wfs::FILE_FLAG_OVERLAPPED,
+                wps::PIPE_TYPE_BYTE | wps::PIPE_READMODE_BYTE | wps::PIPE_WAIT,
+                1,
+                4096,
+                4096,
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+        if raw == wf::INVALID_HANDLE_VALUE {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(unsafe { OwnedHandle::from_raw_handle(raw as _) })
+    }
+
+    fn client(name: &str) -> io::Result<OwnedHandle> {
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .custom_flags(wfs::FILE_FLAG_OVERLAPPED)
+            .open(name)?;
+        Ok(unsafe { OwnedHandle::from_raw_handle(file.into_raw_handle()) })
+    }
+
+    let name = format!(r"\\.\pipe\polling-example-{}", std::process::id());
+    let server_h = server(&name)?;
+    let client_h = client(&name)?;
+
+    let poller = Poller::new()?;
+    // SAFETY: `server_h` / `client_h` outlive every `OpHandle` produced
+    // below (we drain all completions before returning).
+    let server_reg = unsafe { poller.register_file(server_h.as_raw_handle(), 1)? };
+    let client_reg = unsafe { poller.register_file(client_h.as_raw_handle(), 2)? };
+
+    fn drain<B>(
+        op: OpHandle<B>,
+        poller: &Poller,
+        events: &mut Events,
+    ) -> std::io::Result<(usize, B)> {
+        while !op.is_complete() {
+            poller.wait(events, Some(Duration::from_secs(1)))?;
+        }
+        let (res, buf) = op.take();
+        res.map(|n| (n, buf))
+    }
+
+    // Server: complete the connection. The client opened the pipe
+    // before we got here, so this typically returns `Complete` (via
+    // ERROR_PIPE_CONNECTED) rather than `Pending`.
+    match server_reg.submit_connect_named_pipe() {
+        Submission::Complete { .. } => {}
+        Submission::Pending(op) => {
+            let mut events = Events::new();
+            let _ = drain(op, &poller, &mut events)?;
+        }
+        Submission::Failed { error, .. } => return Err(error),
+    }
+
+    // Client writes a greeting.
+    let msg = b"hello, named pipe".to_vec();
+    let written = match client_reg.submit_write(msg) {
+        Submission::Complete { bytes, .. } => bytes,
+        Submission::Pending(op) => {
+            let mut events = Events::new();
+            drain(op, &poller, &mut events)?.0
+        }
+        Submission::Failed { error, .. } => return Err(error),
+    };
+    println!("client wrote {written} bytes");
+
+    // Server reads it back.
+    let buf = Vec::<u8>::with_capacity(64);
+    let (n, buf) = match server_reg.submit_read(buf) {
+        Submission::Complete { bytes, buf } => (bytes, buf),
+        Submission::Pending(op) => {
+            let mut events = Events::new();
+            drain(op, &poller, &mut events)?
+        }
+        Submission::Failed { error, .. } => return Err(error),
+    };
+    let init = unsafe { std::slice::from_raw_parts(buf.as_ptr(), n) };
+    println!(
+        "server read {n} bytes: {:?}",
+        std::str::from_utf8(init).unwrap_or("<non-utf8>")
+    );
+
+    drop(server_reg);
+    drop(client_reg);
+    drop(poller);
+    drop(server_h);
+    drop(client_h);
+    Ok(())
+}

--- a/examples/named_pipe_concurrent.rs
+++ b/examples/named_pipe_concurrent.rs
@@ -1,0 +1,128 @@
+//! Two concurrent reads on a named pipe + cancel demo for the v2
+//! IOCP file-handle API.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo run --example named_pipe_concurrent
+//! ```
+
+#[cfg(not(windows))]
+fn main() {
+    eprintln!("named_pipe_concurrent example only runs on Windows");
+}
+
+#[cfg(windows)]
+fn main() -> std::io::Result<()> {
+    use polling::os::iocp::{OpHandle, PollerIocpFileExt, Submission};
+    use polling::{Events, Poller};
+
+    use std::ffi::OsStr;
+    use std::fs::OpenOptions;
+    use std::io::{self, Write};
+    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::fs::OpenOptionsExt;
+    use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+    use std::time::Duration;
+
+    use windows_sys::Win32::{Foundation as wf, Storage::FileSystem as wfs, System::Pipes as wps};
+
+    fn server(name: &str) -> io::Result<OwnedHandle> {
+        let wide: Vec<u16> = OsStr::new(name).encode_wide().chain(Some(0)).collect();
+        let raw = unsafe {
+            wps::CreateNamedPipeW(
+                wide.as_ptr(),
+                wfs::PIPE_ACCESS_DUPLEX | wfs::FILE_FLAG_OVERLAPPED,
+                wps::PIPE_TYPE_BYTE | wps::PIPE_READMODE_BYTE | wps::PIPE_WAIT,
+                1,
+                4096,
+                4096,
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+        if raw == wf::INVALID_HANDLE_VALUE {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(unsafe { OwnedHandle::from_raw_handle(raw as _) })
+    }
+
+    fn client(name: &str) -> io::Result<std::fs::File> {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .custom_flags(wfs::FILE_FLAG_OVERLAPPED)
+            .open(name)
+    }
+
+    let name = format!(r"\\.\pipe\polling-concurrent-{}", std::process::id());
+    let server_h = server(&name)?;
+    let mut client_file = client(&name)?;
+
+    let poller = Poller::new()?;
+    // SAFETY: `server_h` outlives every `OpHandle` derived from this
+    // registration; we drain all completions before returning.
+    let server_reg = unsafe { poller.register_file(server_h.as_raw_handle(), 1)? };
+
+    // Submit two concurrent reads.
+    let read_a = match server_reg.submit_read(Vec::<u8>::with_capacity(64)) {
+        Submission::Pending(op) => op,
+        other => panic!("expected Pending, got {other:?}"),
+    };
+    let read_b = match server_reg.submit_read(Vec::<u8>::with_capacity(64)) {
+        Submission::Pending(op) => op,
+        other => panic!("expected Pending, got {other:?}"),
+    };
+
+    // A third read that we will cancel before any data arrives.
+    let read_c = match server_reg.submit_read(Vec::<u8>::with_capacity(64)) {
+        Submission::Pending(op) => op,
+        other => panic!("expected Pending, got {other:?}"),
+    };
+    read_c.cancel()?;
+
+    // Peer writes two distinct messages from a worker thread.
+    let writer = std::thread::spawn(move || -> io::Result<()> {
+        client_file.write_all(b"first")?;
+        client_file.write_all(b"second")?;
+        Ok(())
+    });
+
+    let mut events = Events::new();
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+
+    let mut pending: Vec<Option<OpHandle<Vec<u8>>>> =
+        vec![Some(read_a), Some(read_b), Some(read_c)];
+    let mut got = 0;
+    while got < 3 {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            panic!("timed out waiting for completions");
+        }
+        poller.wait(&mut events, Some(remaining))?;
+        for (idx, slot) in pending.iter_mut().enumerate() {
+            let take = slot.as_ref().map(|op| op.is_complete()).unwrap_or(false);
+            if !take {
+                continue;
+            }
+            let op = slot.take().unwrap();
+            match op.take() {
+                (Ok(n), buf) => {
+                    let init = unsafe { std::slice::from_raw_parts(buf.as_ptr(), n) };
+                    println!(
+                        "read #{idx} got {n} bytes: {:?}",
+                        std::str::from_utf8(init).unwrap_or("<non-utf8>")
+                    );
+                }
+                (Err(e), _) => println!("read #{idx} aborted: {e}"),
+            }
+            got += 1;
+        }
+    }
+
+    writer.join().expect("writer panicked")?;
+    drop(server_reg);
+    drop(poller);
+    drop(server_h);
+    Ok(())
+}

--- a/src/iocp/afd.rs
+++ b/src/iocp/afd.rs
@@ -1,30 +1,30 @@
 //! Safe wrapper around \Device\Afd
 
+use crate::iocp::ntdll::NtdllImports;
+use crate::iocp::port::FileOverlapped;
+
 use super::port::{Completion, CompletionHandle};
 
 use std::cell::UnsafeCell;
 use std::fmt;
 use std::io;
 use std::marker::{PhantomData, PhantomPinned};
-use std::mem::{self, size_of, transmute, MaybeUninit};
+use std::mem::{self, size_of, MaybeUninit};
 use std::ops;
 use std::os::windows::prelude::{AsRawHandle, RawHandle, RawSocket};
 use std::pin::Pin;
 use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::OnceLock;
 
 use windows_sys::Wdk::Foundation::OBJECT_ATTRIBUTES;
 use windows_sys::Wdk::Storage::FileSystem::FILE_OPEN;
 use windows_sys::Win32::Foundation::{
-    CloseHandle, HANDLE, HMODULE, NTSTATUS, STATUS_NOT_FOUND, STATUS_PENDING, STATUS_SUCCESS,
-    UNICODE_STRING,
+    CloseHandle, HANDLE, NTSTATUS, STATUS_NOT_FOUND, STATUS_PENDING, STATUS_SUCCESS, UNICODE_STRING,
 };
 use windows_sys::Win32::Networking::WinSock::{
     WSAIoctl, SIO_BASE_HANDLE, SIO_BSP_HANDLE_POLL, SOCKET_ERROR,
 };
 use windows_sys::Win32::Storage::FileSystem::{FILE_SHARE_READ, FILE_SHARE_WRITE, SYNCHRONIZE};
-use windows_sys::Win32::System::LibraryLoader::{GetModuleHandleW, GetProcAddress};
 use windows_sys::Win32::System::IO::IO_STATUS_BLOCK;
 
 #[derive(Default)]
@@ -168,153 +168,6 @@ impl ops::BitAndAssign for AfdPollMask {
 
 pub(super) trait HasAfdInfo {
     fn afd_info(self: Pin<&Self>) -> Pin<&UnsafeCell<AfdPollInfo>>;
-}
-
-macro_rules! define_ntdll_import {
-    (
-        $(
-            $(#[$attr:meta])*
-            fn $name:ident($($arg:ident: $arg_ty:ty),*) -> $ret:ty;
-        )*
-    ) => {
-        /// Imported functions from ntdll.dll.
-        #[allow(non_snake_case)]
-        pub(super) struct NtdllImports {
-            $(
-                $(#[$attr])*
-                $name: unsafe extern "system" fn($($arg_ty),*) -> $ret,
-            )*
-        }
-
-        #[allow(non_snake_case)]
-        impl NtdllImports {
-            unsafe fn load(ntdll: HMODULE) -> io::Result<Self> {
-                $(
-                    #[allow(clippy::missing_transmute_annotations)]
-                    let $name = {
-                        const NAME: &str = concat!(stringify!($name), "\0");
-                        let addr = GetProcAddress(ntdll, NAME.as_ptr() as *const _);
-
-                        let addr = match addr {
-                            Some(addr) => addr,
-                            None => {
-                                #[cfg(feature = "tracing")]
-                                tracing::error!("Failed to load ntdll function {}", NAME);
-                                return Err(io::Error::last_os_error());
-                            },
-                        };
-
-                        transmute::<_, unsafe extern "system" fn($($arg_ty),*) -> $ret>(addr)
-                    };
-                )*
-
-                Ok(Self {
-                    $(
-                        $name,
-                    )*
-                })
-            }
-
-            $(
-                $(#[$attr])*
-                unsafe fn $name(&self, $($arg: $arg_ty),*) -> $ret {
-                    (self.$name)($($arg),*)
-                }
-            )*
-        }
-    };
-}
-
-define_ntdll_import! {
-    /// Cancels an ongoing I/O operation.
-    fn NtCancelIoFileEx(
-        FileHandle: HANDLE,
-        IoRequestToCancel: *mut IO_STATUS_BLOCK,
-        IoStatusBlock: *mut IO_STATUS_BLOCK
-    ) -> NTSTATUS;
-
-    /// Opens or creates a file handle.
-    #[allow(clippy::too_many_arguments)]
-    fn NtCreateFile(
-        FileHandle: *mut HANDLE,
-        DesiredAccess: u32,
-        ObjectAttributes: *mut OBJECT_ATTRIBUTES,
-        IoStatusBlock: *mut IO_STATUS_BLOCK,
-        AllocationSize: *mut i64,
-        FileAttributes: u32,
-        ShareAccess: u32,
-        CreateDisposition: u32,
-        CreateOptions: u32,
-        EaBuffer: *mut (),
-        EaLength: u32
-    ) -> NTSTATUS;
-
-    /// Runs an I/O control on a file handle.
-    ///
-    /// Practically equivalent to `ioctl`.
-    #[allow(clippy::too_many_arguments)]
-    fn NtDeviceIoControlFile(
-        FileHandle: HANDLE,
-        Event: HANDLE,
-        ApcRoutine: *mut (),
-        ApcContext: *mut (),
-        IoStatusBlock: *mut IO_STATUS_BLOCK,
-        IoControlCode: u32,
-        InputBuffer: *mut (),
-        InputBufferLength: u32,
-        OutputBuffer: *mut (),
-        OutputBufferLength: u32
-    ) -> NTSTATUS;
-
-    /// Converts `NTSTATUS` to a DOS error code.
-    fn RtlNtStatusToDosError(
-        Status: NTSTATUS
-    ) -> u32;
-}
-
-impl NtdllImports {
-    fn get() -> io::Result<&'static Self> {
-        macro_rules! s {
-            ($e:expr) => {{
-                $e as u16
-            }};
-        }
-
-        // ntdll.dll
-        static NTDLL_NAME: &[u16] = &[
-            s!('n'),
-            s!('t'),
-            s!('d'),
-            s!('l'),
-            s!('l'),
-            s!('.'),
-            s!('d'),
-            s!('l'),
-            s!('l'),
-            s!('\0'),
-        ];
-        static NTDLL_IMPORTS: OnceLock<io::Result<NtdllImports>> = OnceLock::new();
-
-        NTDLL_IMPORTS
-            .get_or_init(|| unsafe {
-                let ntdll = GetModuleHandleW(NTDLL_NAME.as_ptr() as *const _);
-
-                if ntdll.is_null() {
-                    #[cfg(feature = "tracing")]
-                    tracing::error!("Failed to load ntdll.dll");
-                    return Err(io::Error::last_os_error());
-                }
-
-                NtdllImports::load(ntdll)
-            })
-            .as_ref()
-            .map_err(|e| io::Error::from(e.kind()))
-    }
-
-    pub(super) fn force_load() -> io::Result<()> {
-        Self::get()?;
-        Ok(())
-    }
 }
 
 /// The handle to the AFD device.
@@ -611,6 +464,13 @@ unsafe impl<T> Completion for IoStatusBlock<T> {
 
     unsafe fn unlock(self: Pin<&Self>) {
         self.in_use.store(false, Ordering::SeqCst);
+    }
+}
+
+impl<T: FileOverlapped> FileOverlapped for IoStatusBlock<T> {
+    #[inline]
+    fn file_op_offset() -> usize {
+        T::file_op_offset() + std::mem::offset_of!(IoStatusBlock<T>, data)
     }
 }
 

--- a/src/iocp/buf.rs
+++ b/src/iocp/buf.rs
@@ -1,0 +1,137 @@
+//! Owned-buffer traits for the IOCP file-handle submission API.
+//!
+//! The completion-based `RegisteredFile::submit_*` API requires the buffer
+//! to outlive the kernel-visible pointer it hands to `ReadFile` /
+//! `WriteFile`. Buffers therefore must:
+//!
+//! - have a stable address (no growing `Vec` reallocations after submit),
+//! - be `'static` (no borrowed lifetimes — the kernel may complete the I/O
+//!   long after the `submit_*` call returns),
+//! - be `Send` (completions are delivered on the thread that calls
+//!   [`Poller::wait`], which may differ from the submitter).
+//!
+//! See `docs/named-pipe.design.md` §3.2.
+
+/// A byte region with a stable address until the value is dropped.
+///
+/// # Safety
+///
+/// Implementors must guarantee that [`StableBuf::as_ptr`] returns the same
+/// address for the lifetime of `self`. Moving `self` is permitted only as
+/// long as the pointer has not been observed externally — which the
+/// `OpInner` allocation guarantees by pinning the wrapping `Pin<Arc<…>>`.
+pub unsafe trait StableBuf: Send + 'static {
+    /// Returns a pointer to the start of the byte region.
+    fn as_ptr(&self) -> *const u8;
+    /// Returns the number of initialised bytes the region currently holds.
+    fn len(&self) -> usize;
+    /// Returns `true` if [`StableBuf::len`] is zero.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// A mutable byte region with a stable address until the value is dropped.
+///
+/// # Safety
+///
+/// In addition to [`StableBuf`]'s contract, implementors must guarantee
+/// that [`StableBufMut::as_mut_ptr`] returns the same address for the
+/// lifetime of `self`, that the region is writable up to
+/// [`StableBufMut::capacity`] bytes, and that
+/// [`StableBufMut::set_init`] is sound for any `n in 0..=capacity()`.
+pub unsafe trait StableBufMut: StableBuf {
+    /// Returns a mutable pointer to the start of the byte region.
+    fn as_mut_ptr(&mut self) -> *mut u8;
+    /// Returns the total writable capacity in bytes.
+    fn capacity(&self) -> usize;
+    /// Marks the first `n` bytes of the region as initialised after the
+    /// kernel reported `n` bytes were written into the buffer.
+    ///
+    /// # Safety
+    ///
+    /// `n` must satisfy `n <= capacity()` and the first `n` bytes of the
+    /// region must actually be initialised by the kernel before the call.
+    unsafe fn set_init(&mut self, n: usize);
+}
+
+// SAFETY: `Vec<u8>` keeps its underlying allocation at a stable address as
+// long as no method that may reallocate is called. The `submit_*` API
+// takes ownership of the `Vec` (so no concurrent code can grow it) and
+// only releases it back to the user via `FileCompletion::take` after the
+// kernel completion has fired.
+unsafe impl StableBuf for Vec<u8> {
+    fn as_ptr(&self) -> *const u8 {
+        <[u8]>::as_ptr(self)
+    }
+    fn len(&self) -> usize {
+        Vec::len(self)
+    }
+}
+
+// SAFETY: see `StableBuf for Vec<u8>`. `set_init` upholds `Vec::set_len`'s
+// invariants because the caller of `set_init` (the v2 completion path)
+// has already verified that the kernel wrote `n` initialised bytes into
+// the buffer and that `n <= self.capacity()`.
+unsafe impl StableBufMut for Vec<u8> {
+    fn as_mut_ptr(&mut self) -> *mut u8 {
+        <[u8]>::as_mut_ptr(self)
+    }
+    fn capacity(&self) -> usize {
+        Vec::capacity(self)
+    }
+    unsafe fn set_init(&mut self, n: usize) {
+        // SAFETY: Caller contract guarantees `n <= capacity()` and that
+        // the first `n` bytes are initialised.
+        unsafe {
+            self.set_len(n);
+        }
+    }
+}
+
+// SAFETY: `Box<[u8]>` allocates a fixed-size heap region whose address
+// does not change for the lifetime of the box.
+unsafe impl StableBuf for Box<[u8]> {
+    fn as_ptr(&self) -> *const u8 {
+        <[u8]>::as_ptr(self)
+    }
+    fn len(&self) -> usize {
+        <[u8]>::len(self)
+    }
+}
+
+// SAFETY: see `StableBuf for Box<[u8]>`. The slice's length equals its
+// capacity, so `set_init` is a no-op.
+unsafe impl StableBufMut for Box<[u8]> {
+    fn as_mut_ptr(&mut self) -> *mut u8 {
+        <[u8]>::as_mut_ptr(self)
+    }
+    fn capacity(&self) -> usize {
+        <[u8]>::len(self)
+    }
+    unsafe fn set_init(&mut self, _n: usize) {
+        // No-op: a `Box<[u8]>` has no separate length field.
+    }
+}
+
+// SAFETY: a `'static` byte slice points to memory that lives for the
+// entire program, so the address is trivially stable.
+unsafe impl StableBuf for &'static [u8] {
+    fn as_ptr(&self) -> *const u8 {
+        <[u8]>::as_ptr(self)
+    }
+    fn len(&self) -> usize {
+        <[u8]>::len(self)
+    }
+}
+
+// SAFETY: `()` carries no buffer; implementing `StableBuf` for it lets
+// `submit_connect_named_pipe` reuse the same `Submission<B>` machinery.
+unsafe impl StableBuf for () {
+    fn as_ptr(&self) -> *const u8 {
+        std::ptr::NonNull::<u8>::dangling().as_ptr()
+    }
+    fn len(&self) -> usize {
+        0
+    }
+}

--- a/src/iocp/mod.rs
+++ b/src/iocp/mod.rs
@@ -26,6 +26,8 @@
 //! AFD-based strategy for polling.
 
 mod afd;
+pub(crate) mod buf;
+pub(crate) mod ntdll;
 mod port;
 
 use afd::{base_socket, Afd, AfdPollInfo, AfdPollMask, HasAfdInfo, IoStatusBlock};
@@ -36,7 +38,12 @@ use windows_sys::Win32::System::Threading::{
     RegisterWaitForSingleObject, UnregisterWait, INFINITE, WT_EXECUTELONGFUNCTION,
     WT_EXECUTEONLYONCE,
 };
+use windows_sys::Win32::System::WindowsProgramming::{
+    FILE_SKIP_COMPLETION_PORT_ON_SUCCESS, FILE_SKIP_SET_EVENT_ON_HANDLE,
+};
+use windows_sys::Win32::System::IO::OVERLAPPED;
 
+use crate::iocp::port::FileOverlapped;
 use crate::{Event, PollMode};
 
 use concurrent_queue::ConcurrentQueue;
@@ -45,17 +52,16 @@ use pin_project_lite::pin_project;
 use std::cell::UnsafeCell;
 use std::collections::hash_map::{Entry, HashMap};
 use std::ffi::c_void;
-use std::fmt;
-use std::io;
 use std::marker::PhantomPinned;
 use std::mem::{forget, MaybeUninit};
 use std::os::windows::io::{
     AsHandle, AsRawHandle, AsRawSocket, BorrowedHandle, BorrowedSocket, RawHandle, RawSocket,
 };
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, MutexGuard, RwLock, Weak};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU8, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock, RwLock, Weak};
 use std::time::{Duration, Instant};
+use std::{fmt, io};
 
 /// Macro to lock and ignore lock poisoning.
 macro_rules! lock {
@@ -118,7 +124,7 @@ impl Poller {
     /// Creates a new poller.
     pub(super) fn new() -> io::Result<Self> {
         // Make sure AFD is able to be used.
-        if let Err(e) = afd::NtdllImports::force_load() {
+        if let Err(e) = ntdll::NtdllImports::force_load() {
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,
                 AfdError::new("failed to initialize unstable Windows functions", e),
@@ -427,6 +433,47 @@ impl Poller {
         source.begin_delete()
     }
 
+    /// Register a file handle for the `submit_*` API.
+    ///
+    /// `key` is the same kind of value passed to
+    /// [`Poller::add`](crate::Poller::add): it is mirrored into
+    /// [`Event::key`] of every completion this file emits, so a
+    /// reactor (e.g. `async-io`) can route the completion to the
+    /// correct source via its key-indexed waker registry.
+    ///
+    /// Each [`RegisteredFile`] is its own self-managed registration;
+    /// per-op packets carry their own Arc lifetimes.
+    pub(super) fn register_file(
+        &self,
+        handle: RawHandle,
+        key: usize,
+    ) -> io::Result<RegisteredFile> {
+        struct H(RawHandle);
+        impl AsRawHandle for H {
+            fn as_raw_handle(&self) -> RawHandle {
+                self.0
+            }
+        }
+
+        // Attach the handle to this IOCP and request the sync-success
+        // fast-path flags; ERROR_INVALID_FUNCTION is treated as a
+        // non-fatal no-op inside `register`.
+        self.port.register(
+            &H(handle),
+            (FILE_SKIP_SET_EVENT_ON_HANDLE | FILE_SKIP_COMPLETION_PORT_ON_SUCCESS) as u8,
+            port::CompletionKeyType::FileOp,
+        )?;
+
+        Ok(RegisteredFile {
+            inner: Arc::new(RegisteredFileInner {
+                handle,
+                port: Arc::clone(&self.port),
+                active: AtomicBool::new(true),
+                user_key: AtomicUsize::new(key),
+            }),
+        })
+    }
+
     /// Wait for events.
     pub(super) fn wait_deadline(
         &self,
@@ -476,10 +523,92 @@ impl Poller {
 
             // Process all of the events.
             for entry in events.completions.drain(..) {
-                let packet = entry.into_packet();
+                let result = if entry.is_file_completion() {
+                    let bytes = entry.bytes_transferred();
+                    // SAFETY: the entry is fresh from
+                    // `GetQueuedCompletionStatusEx`, so its
+                    // `lpOverlapped` points to a live `OVERLAPPED`.
+                    let nt_status = unsafe { entry.nt_status_raw() };
+                    // Reclaim the kernel's `Arc` strong reference (bumped
+                    // at submit time in `classify_submission`) and
+                    // publish the completion fields. The packet is
+                    // dropped at the end of this scope, releasing that
+                    // strong ref. If the user already dropped their
+                    // `OpHandle`, the allocation is freed here and
+                    // `OpInner::Drop` reclaims the buffer.
+                    let packet = entry.into_file_op_packet();
+                    if let PacketInnerProj::FileOp { op } = packet.as_ref().data().project_ref() {
+                        let op = op.get_ref();
+                        // Order matters: the user-visible state must
+                        // be Released BEFORE we push the Event, so
+                        // that a task woken by its reactor sees
+                        // `Completed` on its Acquire-load of `state`.
+                        op.bytes_transferred.store(bytes, Ordering::Release);
+                        // Translate the NTSTATUS to a Win32 error
+                        // here so consumers (`OpHandle::take`) can
+                        // hand the value straight to
+                        // `io::Error::from_raw_os_error`.
+                        // `STATUS_BUFFER_OVERFLOW` translates to
+                        // `ERROR_MORE_DATA`, which `take_inner`
+                        // treats as success-with-remaining-data so
+                        // the partial buffer is not lost.
+                        let dos = match ntdll::NtdllImports::get() {
+                            // SAFETY: pure translation, no
+                            // preconditions on `Status`.
+                            Ok(ntdll) => unsafe { ntdll.RtlNtStatusToDosError(nt_status) },
+                            // ntdll failed to load — extremely
+                            // unlikely (the rest of this module
+                            // already requires it). Fall back to a
+                            // generic Win32 error so the user still
+                            // sees a non-zero failure.
+                            Err(_) => ERROR_INVALID_HANDLE,
+                        };
+                        op.dos_error.store(dos, Ordering::Release);
+                        // Unconditionally publish Completed. If the user
+                        // pre-cancelled (state = Cancelled), the kernel
+                        // still posted a completion entry (typically
+                        // with STATUS_CANCELLED in `nt_status`), and the
+                        // outcome is encoded in `nt_status` rather than
+                        // the lifecycle state.
+                        op.state.store(OpState::Completed as u8, Ordering::Release);
+                        // Emit a normal Event so the reactor (e.g.
+                        // `async-io`) can wake the task that owns the
+                        // matching source via its key-indexed waker
+                        // registry. The op carries its own
+                        // direction-of-interest, mirrored here.
+                        let interest = op.interest;
+                        // Acquire pairs with the `Release` store in
+                        // `RegisteredFile::set_user_key`. Reading
+                        // `user_key` *after* the `state` Release store
+                        // above is intentional: a concurrent
+                        // `set_user_key` either lands before this load
+                        // (event carries the new key) or after it
+                        // (event carries the old key). Both outcomes
+                        // are documented as acceptable — `set_user_key`
+                        // is best-effort for in-flight ops.
+                        let key = op
+                            .file
+                            .as_ref()
+                            .expect("submitted op has back-ref to its RegisteredFile")
+                            .user_key
+                            .load(Ordering::Acquire);
+                        let event = Event {
+                            key,
+                            readable: interest.readable,
+                            writable: interest.writable,
+                            extra: crate::sys::EventExtra::empty(),
+                        };
+                        events.packets.push(event);
+                        new_events += 1;
+                    }
+                    Ok::<_, io::Error>(FeedEventResult::NoEvent)
+                } else {
+                    let packet = entry.into_packet();
+                    packet.feed_event(self)
+                };
 
                 // Feed the event into the packet.
-                match packet.feed_event(self)? {
+                match result? {
                     FeedEventResult::NoEvent => {}
                     FeedEventResult::Event(event) => {
                         events.packets.push(event);
@@ -599,7 +728,11 @@ impl Poller {
         let afd = Arc::new(Afd::new()?);
 
         // Register the AFD instance with the I/O completion port.
-        self.port.register(&*afd, true)?;
+        self.port.register(
+            &*afd,
+            FILE_SKIP_SET_EVENT_ON_HANDLE as u8,
+            port::CompletionKeyType::Socket,
+        )?;
 
         // Insert a weak pointer to the AFD instance into the list for other sockets.
         afd_handles.push(Arc::downgrade(&afd));
@@ -756,6 +889,15 @@ pin_project! {
             handle: Mutex<WaitableState>
         },
 
+        /// A single overlapped file operation with owned buffer.
+        ///
+        /// Per-op allocation: one [`OVERLAPPED`] per outstanding op.
+        /// See `docs/named-pipe.design.md` §3.1.
+        FileOp {
+            #[pin]
+            op: OpInner,
+        },
+
         /// A custom event sent by the user.
         Custom {
             event: Event,
@@ -763,6 +905,158 @@ pin_project! {
 
         // A packet used to wake up the poller.
         Wakeup { #[pin] _pinned: PhantomPinned },
+    }
+}
+
+/// Lifecycle state of a single [`OpInner`] operation.
+///
+/// Stored as an `AtomicU8` so the completion path and a concurrent
+/// `cancel()` can race on the transition without a lock.
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum OpState {
+    Submitted = 0,
+    Completed = 1,
+    Cancelled = 2,
+}
+
+/// VTable for type-erased buffer storage inside [`OpInner`].
+///
+/// The concrete buffer type `B` is recovered at the typed `OpHandle<B>`
+/// layer.
+struct OpVTable {
+    /// Drop the buffer in place.
+    pub drop_buf: unsafe fn(*mut u8),
+}
+
+/// Type-erased buffer slot embedded in [`OpInner`].
+///
+/// A fixed 32-byte, 8-byte-aligned blob large enough to hold the
+/// buffer wrapper types the [`buf::StableBuf`] / [`buf::StableBufMut`]
+/// machinery stores — typically a `(ptr, len, cap)` triple for
+/// `Vec<u8>`, a `(ptr, len)` pair for `Box<[u8]>`, or similar.
+#[repr(C, align(8))]
+pub(crate) struct ErasedBuf([u8; 32]);
+
+/// No-op vtable used while the buffer slot is empty (e.g. for the
+/// bare `OpInner::new` constructor used by tests).
+static NOOP_VTABLE: OpVTable = OpVTable {
+    drop_buf: noop_drop_buf,
+};
+
+unsafe fn noop_drop_buf(_: *mut u8) {}
+
+/// Kernel-visible per-operation block.
+///
+/// `#[repr(C)]` with the `OVERLAPPED` block at offset 0 so the
+/// `lpOverlapped` pointer the kernel writes into a completion entry
+/// can be cast straight back to `*mut OpInner` (after the file-op
+/// classifier has identified it as a file packet).
+///
+/// Buffer storage is type-erased; [`OpInner::vtable`] knows how to
+/// drop or move it. The concrete buffer type is recovered at the typed
+/// `OpHandle<B>` layer.
+///
+/// The struct is `!Unpin` (via [`PhantomPinned`]) because the kernel
+/// holds a raw pointer into the embedded [`OVERLAPPED`] for the
+/// duration of the operation; moving the payload after submission
+/// would invalidate that pointer.
+#[repr(C)]
+pub(crate) struct OpInner {
+    /// `OVERLAPPED` MUST be the first field. The kernel writes the
+    /// completion status into it.
+    overlapped: UnsafeCell<OVERLAPPED>,
+    /// Lifecycle state of this operation.
+    state: AtomicU8,
+    /// Bytes transferred, written by the completion path.
+    bytes_transferred: AtomicU32,
+    /// Win32 error reaped from the completion entry, already
+    /// translated from NTSTATUS via `ntdll!RtlNtStatusToDosError`
+    /// inside the dispatcher; `0` (= success) until set. `OpHandle`
+    /// consumers feed this straight into
+    /// [`io::Error::from_raw_os_error`] without ever touching the
+    /// raw NTSTATUS.
+    dos_error: AtomicU32,
+    /// `true` after `OpHandle::take` (or sync-success classification)
+    /// extracts the buffer; the in-place destructor in `Drop for
+    /// OpInner` then becomes a no-op.
+    taken: AtomicBool,
+    /// Type-erased buffer storage.
+    buf_storage: UnsafeCell<MaybeUninit<ErasedBuf>>,
+    /// VTable that knows how to drop / move the contents of
+    /// [`OpInner::buf_storage`].
+    vtable: &'static OpVTable,
+    /// Back-reference to the owning [`RegisteredFile`]. `None` when the
+    /// op is built from the bare `OpInner::new` constructor used by
+    /// internal unit tests; `Some(_)` for every `submit_*`-issued op.
+    file: Option<Arc<RegisteredFileInner>>,
+    /// Direction of interest for this op. The dispatcher emits an
+    /// `Event { key, readable, writable }` mirroring this on
+    /// completion, so a reactor (e.g. `async-io`) can wake the right
+    /// task via its key-indexed waker registry.
+    interest: OpInterest,
+    /// Marks the struct as `!Unpin`: the kernel holds a raw pointer
+    /// into `overlapped`, so the payload must never be moved.
+    _pinned: PhantomPinned,
+}
+
+/// Direction of interest for a single in-flight op.
+///
+/// Mirrored into the `Event { readable, writable }` the dispatcher
+/// emits on completion. Reads (and `ConnectNamedPipe`) set
+/// `readable = true`; writes set `writable = true`.
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct OpInterest {
+    pub readable: bool,
+    pub writable: bool,
+}
+
+// Safety: the kernel holds a raw pointer into `OpInner` (specifically
+// into `overlapped`) but never reads or writes through any of the
+// Rust-side fields concurrently with the user; the typed `OpHandle<B>`
+// layer owns the synchronisation discipline for the buffer slot.
+unsafe impl Send for OpInner {}
+unsafe impl Sync for OpInner {}
+
+impl OpInner {
+    /// Construct a fresh `OpInner` in the [`OpState::Submitted`] state
+    /// with an empty buffer slot and the [`NOOP_VTABLE`].
+    ///
+    /// Used by internal layout / unit tests; production submission
+    /// sites build `OpInner` inline inside `make_op_packet` so the
+    /// buffer / vtable / file back-reference can be set in one move.
+    fn new() -> Self {
+        Self {
+            overlapped: UnsafeCell::new(OVERLAPPED::default()),
+            state: AtomicU8::new(OpState::Submitted as u8),
+            bytes_transferred: AtomicU32::new(0),
+            dos_error: AtomicU32::new(0),
+            taken: AtomicBool::new(false),
+            buf_storage: UnsafeCell::new(MaybeUninit::zeroed()),
+            vtable: &NOOP_VTABLE,
+            file: None,
+            interest: OpInterest {
+                readable: false,
+                writable: false,
+            },
+            _pinned: PhantomPinned,
+        }
+    }
+}
+
+impl Drop for OpInner {
+    fn drop(&mut self) {
+        // Drop the buffer in place via the type-erased vtable, unless it
+        // was already extracted by `OpHandle::take` / sync-success.
+        if !self.taken.load(Ordering::Acquire) {
+            // SAFETY: `buf_storage` was either initialised by the
+            // `submit_*` helper (in which case `vtable.drop_buf` is a
+            // typed `drop_in_place::<B>`), or remained zeroed with
+            // [`NOOP_VTABLE`] (in which case `drop_buf` is a no-op).
+            unsafe {
+                (self.vtable.drop_buf)(self.buf_storage.get() as *mut u8);
+            }
+        }
     }
 }
 
@@ -782,6 +1076,7 @@ impl fmt::Debug for PacketInner {
             Self::Waitable { handle } => {
                 f.debug_struct("Waitable").field("handle", handle).finish()
             }
+            Self::FileOp { .. } => f.write_str("FileOp { .. }"),
         }
     }
 }
@@ -792,6 +1087,38 @@ impl HasAfdInfo for PacketInner {
             PacketInnerProj::Socket { packet, .. } => packet,
             _ => unreachable!(),
         }
+    }
+}
+
+/// Cached offset of the `FileOp` variant payload inside [`PacketInner`].
+///
+/// `std::mem::offset_of!` does not yet support enum variants on stable
+/// (tracking issue rust-lang/rust#120141), so the variant offset is
+/// computed once at runtime.
+static FILE_OP_VARIANT_OFFSET: OnceLock<usize> = OnceLock::new();
+
+impl FileOverlapped for PacketInner {
+    fn file_op_offset() -> usize {
+        // `OpInner.overlapped` is at offset 0 of `OpInner`, so the offset
+        // from the `OVERLAPPED` back to the start of `PacketInner` equals
+        // the `FileOp` variant offset (no further intra-struct add).
+        PacketInner::file_op_variant_offset()
+    }
+}
+
+impl PacketInner {
+    /// Compute (and cache) the offset of the `FileOp` variant payload
+    /// (i.e. the embedded `OpInner`) inside `PacketInner`.
+    fn file_op_variant_offset() -> usize {
+        *FILE_OP_VARIANT_OFFSET.get_or_init(|| {
+            let packet = PacketInner::FileOp { op: OpInner::new() };
+            let base = &packet as *const _ as *const u8;
+            let op_ptr = match &packet {
+                PacketInner::FileOp { op } => op as *const _ as *const u8,
+                _ => unreachable!(),
+            };
+            unsafe { op_ptr.offset_from(base) as usize }
+        })
     }
 }
 
@@ -825,6 +1152,10 @@ impl PacketUnwrapped {
 
                 // Update if there is no ongoing wait.
                 handle.status.is_idle()
+            }
+            PacketInnerProj::FileOp { .. } => {
+                // One-shot per-op packet: no readiness reconfiguration.
+                false
             }
             _ => true,
         }
@@ -889,7 +1220,11 @@ impl PacketUnwrapped {
 
                 return Ok(());
             }
-            _ => return Err(io::Error::new(io::ErrorKind::Other, "invalid socket state")),
+            PacketInnerProj::FileOp { .. } => {
+                // One-shot per-op packet: nothing to update.
+                return Ok(());
+            }
+            _ => return Err(io::Error::other("invalid socket state")),
         };
 
         // If we are waiting on a delete, just return, dropping the packet.
@@ -979,6 +1314,11 @@ impl PacketUnwrapped {
                 poller.update_packet(self)?;
 
                 return Ok(FeedEventResult::Event(event));
+            }
+            PacketInnerProj::FileOp { .. } => {
+                unreachable!(
+                    "FileOp packets are dispatched inline in `wait_deadline` and never reach `feed_event`"
+                )
             }
         };
 
@@ -1408,5 +1748,639 @@ struct CallOnDrop<F: FnMut()>(F);
 impl<F: FnMut()> Drop for CallOnDrop<F> {
     fn drop(&mut self) {
         (self.0)();
+    }
+}
+
+/// Inner, Arc-shared state of a [`RegisteredFile`].
+///
+/// Held behind an [`Arc`] so each in-flight [`OpHandle`] can keep the
+/// registration alive independently of the user-facing
+/// [`RegisteredFile`] handle.
+#[derive(Debug)]
+pub(crate) struct RegisteredFileInner {
+    /// Raw handle, used by `CancelIoEx` and submission helpers.
+    /// Borrowed; never closed by us.
+    handle: RawHandle,
+    /// Back-reference to the IOCP port. Each in-flight Op holds an
+    /// `Arc<RegisteredFileInner>`, so the port stays alive at least as
+    /// long as any Op needs to deliver a completion to it.
+    #[allow(dead_code)] // Holds the port alive; consulted only by Drop chain.
+    port: Arc<IoCompletionPort<Packet>>,
+    /// `false` after `RegisteredFile::deactivate`. New `submit_*` calls
+    /// are rejected.
+    active: AtomicBool,
+    /// User-chosen key, mirrored into the `Event::key` of every
+    /// completion this file emits. Same convention as
+    /// `Poller::add(socket, Event::none(key))` — it identifies the
+    /// reactor-side source for an external waker registry.
+    ///
+    /// Stored atomically so reactors that allocate the key after
+    /// constructing the [`RegisteredFile`] (e.g. `async-io`'s
+    /// `Slab<Source>` indexing) can rebind it via
+    /// [`RegisteredFile::set_user_key`]. The dispatcher reads with
+    /// `Acquire`; `set_user_key` writes with `Release`.
+    user_key: AtomicUsize,
+}
+
+// SAFETY: `RawHandle` is `*mut c_void`; we never dereference it
+// concurrently with the kernel except via `ReadFile`/`WriteFile`/
+// `CancelIoEx`, which are themselves thread-safe.
+unsafe impl Send for RegisteredFileInner {}
+unsafe impl Sync for RegisteredFileInner {}
+
+// =====================================================================
+// File-handle submission API.
+// =====================================================================
+
+use crate::iocp::buf::{StableBuf, StableBufMut};
+
+use std::marker::PhantomData;
+use std::ptr;
+
+use windows_sys::Win32::Foundation::{ERROR_NOT_FOUND, ERROR_PIPE_CONNECTED, FALSE};
+use windows_sys::Win32::Storage::FileSystem::{ReadFile, WriteFile};
+use windows_sys::Win32::System::Pipes::ConnectNamedPipe;
+use windows_sys::Win32::System::IO::CancelIoEx;
+
+/// A long-lived registration token for the IOCP file submission API.
+///
+/// Cloning is cheap (it bumps an internal `Arc` refcount). All
+/// clones submit to the same kernel handle.
+#[derive(Clone, Debug)]
+pub struct RegisteredFile {
+    inner: Arc<RegisteredFileInner>,
+}
+
+/// Result of a `RegisteredFile::submit_*` call.
+pub enum Submission<B> {
+    /// Synchronous success: the kernel processed the I/O immediately
+    /// and (because of `FILE_SKIP_COMPLETION_PORT_ON_SUCCESS`) will
+    /// not post a completion. The buffer is returned together with
+    /// the byte count.
+    Complete {
+        /// Number of bytes transferred.
+        bytes: usize,
+        /// The buffer handed back to the caller.
+        buf: B,
+    },
+    /// `ERROR_IO_PENDING` was returned and the completion will arrive
+    /// on the poller. Drive [`crate::Poller::wait`] until the
+    /// returned [`OpHandle`] reports [`OpHandle::is_complete`], then
+    /// call [`OpHandle::take`].
+    Pending(OpHandle<B>),
+    /// The syscall failed before reaching the kernel queue. The
+    /// buffer is handed back together with the error.
+    Failed {
+        /// The error reported by the syscall.
+        error: io::Error,
+        /// The buffer handed back to the caller.
+        buf: B,
+    },
+}
+
+impl<B> std::fmt::Debug for Submission<B> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Submission::Complete { bytes, .. } => f
+                .debug_struct("Complete")
+                .field("bytes", bytes)
+                .finish_non_exhaustive(),
+            Submission::Pending(_) => f.write_str("Pending(..)"),
+            Submission::Failed { error, .. } => f
+                .debug_struct("Failed")
+                .field("error", error)
+                .finish_non_exhaustive(),
+        }
+    }
+}
+
+impl<B> Submission<B> {
+    /// Returns `true` for the `Complete` variant.
+    pub fn is_complete(&self) -> bool {
+        matches!(self, Submission::Complete { .. })
+    }
+    /// Returns `true` for the `Pending` variant.
+    pub fn is_pending(&self) -> bool {
+        matches!(self, Submission::Pending(_))
+    }
+}
+
+/// Typed handle for one outstanding file operation.
+///
+/// Holds the per-op packet allocation. The buffer lives inside the
+/// allocation; recover it by calling [`OpHandle::take`] once
+/// [`OpHandle::is_complete`] reports `true`.
+pub struct OpHandle<B> {
+    packet: Packet,
+    _marker: PhantomData<B>,
+}
+
+impl<B> std::fmt::Debug for OpHandle<B> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpHandle").finish_non_exhaustive()
+    }
+}
+
+// SAFETY: `OpHandle<B>` exposes only `&self` cancel access, and the
+// kernel completion path serialises with the user via atomic state.
+// The packet itself is `Send + Sync` (its `Pin<Arc<…>>` wraps a
+// `Send + Sync` `IoStatusBlock<PacketInner>`).
+unsafe impl<B: Send> Send for OpHandle<B> {}
+unsafe impl<B: Sync> Sync for OpHandle<B> {}
+
+impl<B> OpHandle<B> {
+    /// Issue [`CancelIoEx`] for this op.
+    ///
+    /// If the op already completed, this is a no-op (`Ok(())`).
+    /// Otherwise the kernel best-effort aborts the op; the user
+    /// must still drain the completion via [`crate::Poller::wait`]
+    /// before calling [`OpHandle::take`].
+    ///
+    /// # Why this takes `&self` and does not return `B`
+    ///
+    /// `CancelIoEx` is asynchronous: it only *requests* cancellation.
+    /// The kernel may still be reading from / writing into the buffer
+    /// at the moment `cancel` returns, and a final completion packet
+    /// (either a late `Ok(n)` or `Err(ERROR_OPERATION_ABORTED)`) is
+    /// delivered to the IOCP some time later. The buffer must remain
+    /// pinned at its original address until that completion is observed,
+    /// otherwise the kernel would write into freed or reused memory.
+    ///
+    /// Consequently `cancel` does *not* consume `self` and does *not*
+    /// hand back `B`. The buffer is reclaimed through the normal path:
+    /// poll until [`OpHandle::is_complete`] returns `true`, then call
+    /// [`OpHandle::take`] (or [`OpHandle::try_take`]) — both now return
+    /// `B` on every path, including the cancelled / errored case.
+    ///
+    /// This mirrors `compio`'s cancellation contract, where the buffer
+    /// is also returned via the awaited completion rather than from the
+    /// cancel call itself.
+    pub fn cancel(&self) -> io::Result<()> {
+        let op = self.op_ref();
+        // Fast path: already completed.
+        if op.state.load(Ordering::Acquire) == OpState::Completed as u8 {
+            return Ok(());
+        }
+        // CAS Submitted -> Cancelled (idempotent on already-Cancelled).
+        let _ = op.state.compare_exchange(
+            OpState::Submitted as u8,
+            OpState::Cancelled as u8,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+
+        let file = op
+            .file
+            .as_ref()
+            .expect("submitted op must have a back-ref to its RegisteredFile");
+        let overlapped = op.overlapped.get() as *mut OVERLAPPED;
+        // SAFETY: `file.handle` is the kernel handle the op was
+        // submitted against; `overlapped` is the per-op `OVERLAPPED`
+        // the kernel currently knows about.
+        let r = unsafe { CancelIoEx(file.handle as _, overlapped) };
+        if r == 0 {
+            let err = io::Error::last_os_error();
+            if err.raw_os_error() == Some(ERROR_NOT_FOUND as i32) {
+                return Ok(());
+            }
+            return Err(err);
+        }
+        Ok(())
+    }
+
+    /// Returns `true` once the IOCP completion dispatcher has
+    /// observed this op's completion entry.
+    pub fn is_complete(&self) -> bool {
+        self.op_ref().state.load(Ordering::Acquire) == OpState::Completed as u8
+    }
+
+    /// If [`is_complete`](Self::is_complete) reports `true`, consume
+    /// `self` and return the I/O result paired with the buffer;
+    /// otherwise hand `self` back unchanged.
+    ///
+    /// On error, the buffer is still returned alongside the
+    /// `io::Error` — the caller decides whether to drop it or
+    /// resubmit. The shape mirrors compio's `BufResult<T, B>`
+    /// (which is `From<(io::Result<T>, B)>`).
+    pub fn try_take(self) -> Result<(io::Result<usize>, B), Self> {
+        if self.is_complete() {
+            Ok(self.take_inner())
+        } else {
+            Err(self)
+        }
+    }
+
+    /// Consume `self` and return the I/O result paired with the
+    /// buffer.
+    ///
+    /// On error, the buffer is still returned — see
+    /// [`try_take`](Self::try_take) for the rationale.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`is_complete`](Self::is_complete) is `false`.
+    /// Use [`try_take`](Self::try_take) for the non-panicking
+    /// variant. Drive [`crate::Poller::wait`] until the
+    /// completion `Event` for this op's key arrives — see the
+    /// `key` argument to [`crate::os::iocp::PollerIocpFileExt::register_file`].
+    pub fn take(self) -> (io::Result<usize>, B) {
+        assert!(
+            self.is_complete(),
+            "OpHandle::take called on a not-yet-completed op",
+        );
+        self.take_inner()
+    }
+
+    fn take_inner(self) -> (io::Result<usize>, B) {
+        let inner = self.op_ref();
+        let bytes = inner.bytes_transferred.load(Ordering::Acquire) as usize;
+        let dos_error = inner.dos_error.load(Ordering::Acquire);
+
+        // Take the buffer out of `buf_storage` via a raw read; mark
+        // taken so `OpInner::Drop` does not double-free.
+        //
+        // SAFETY: `buf_storage` was initialised by the matching
+        // `submit_*` helper with a `B`. State is `Completed`, so
+        // the kernel no longer references the buffer and the
+        // dispatcher has already released its `Arc` strong ref.
+        let buf: B = unsafe { ptr::read(inner.buf_storage.get() as *const B) };
+        inner.taken.store(true, Ordering::Release);
+
+        // `self` is dropped at end of scope; with `taken == true`
+        // and refcount now 1 (kernel ref already reclaimed), the
+        // allocation is freed without re-running the buffer
+        // destructor.
+        drop(self);
+
+        // `ERROR_MORE_DATA` is the Win32 translation of
+        // `STATUS_BUFFER_OVERFLOW` — a message-mode pipe read filled
+        // the user buffer while more data is queued. Byte count and
+        // buffer contents are valid; surface as success so the
+        // partial data is not lost.
+        let res = if dos_error == 0 || dos_error == ERROR_MORE_DATA {
+            Ok(bytes)
+        } else {
+            Err(io::Error::from_raw_os_error(dos_error as i32))
+        };
+        (res, buf)
+    }
+
+    fn op_ref(&self) -> &OpInner {
+        match self.packet.as_ref().data().project_ref() {
+            PacketInnerProj::FileOp { op } => op.get_ref(),
+            _ => unreachable!("OpHandle wraps a FileOp packet"),
+        }
+    }
+}
+
+// No custom `Drop` for `OpHandle`. The default `Pin<Arc<…>>` drop
+// is correct:
+//   - Op already completed: refcount drops to 0, `OpInner::Drop`
+//     reclaims the buffer (unless `take()` already took it).
+//   - Op still pending: the kernel still holds one strong ref
+//     (bumped at submit time in `classify_submission`), so the
+//     allocation lives on. The eventual completion dispatcher
+//     reclaims that ref, decrements to 0, and `OpInner::Drop`
+//     reclaims the buffer.
+
+/// `ERROR_MORE_DATA` (Win32 234) — translation of
+/// `STATUS_BUFFER_OVERFLOW`. A message-mode pipe read filled the
+/// user buffer while more data is queued. `OpHandle::take_inner`
+/// treats this as success so the partial result is not dropped.
+const ERROR_MORE_DATA: u32 = 234;
+
+/// VTable factory: produces a per-`B` `OpVTable` whose `drop_buf`
+/// runs `ptr::drop_in_place::<B>`.
+fn vtable_for<B>() -> &'static OpVTable {
+    struct VTableHolder<B>(PhantomData<B>);
+    impl<B> VTableHolder<B> {
+        const VTABLE: OpVTable = OpVTable {
+            drop_buf: drop_buf_typed::<B>,
+        };
+    }
+    unsafe fn drop_buf_typed<B>(p: *mut u8) {
+        // SAFETY: callers (`OpInner::Drop`) only invoke this on
+        // storage that was initialised with a `B` via `ptr::write`
+        // and not yet taken (`taken == false`).
+        unsafe { ptr::drop_in_place(p as *mut B) }
+    }
+    &VTableHolder::<B>::VTABLE
+}
+
+/// Construct a fresh `Pin<Arc<…>>` packet wrapping a `FileOp` op.
+///
+/// The buffer `B` is moved into the type-erased slot; the chosen
+/// vtable knows how to drop / take it.
+fn make_op_packet<B>(
+    file: Arc<RegisteredFileInner>,
+    buf: B,
+    interest: OpInterest,
+) -> Result<Packet, (B, io::Error)> {
+    // Compile-time would be nicer, but we already enforce these
+    // dynamically when the slot is dimensioned (Step 1 sized it at
+    // 32 bytes). If a future buffer type overflows the slot, we
+    // hand it back as a `Failed` instead of UB.
+    if std::mem::size_of::<B>() > std::mem::size_of::<ErasedBuf>()
+        || std::mem::align_of::<B>() > std::mem::align_of::<ErasedBuf>()
+    {
+        return Err((
+            buf,
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "buffer type exceeds the OpInner slot (size or alignment)",
+            ),
+        ));
+    }
+
+    let op = OpInner {
+        overlapped: UnsafeCell::new(OVERLAPPED::default()),
+        state: AtomicU8::new(OpState::Submitted as u8),
+        bytes_transferred: AtomicU32::new(0),
+        dos_error: AtomicU32::new(0),
+        taken: AtomicBool::new(false),
+        buf_storage: UnsafeCell::new(MaybeUninit::zeroed()),
+        vtable: vtable_for::<B>(),
+        file: Some(file),
+        interest,
+        _pinned: PhantomPinned,
+    };
+
+    // Move the buffer into the type-erased slot.
+    // SAFETY: `buf_storage` is a `MaybeUninit<ErasedBuf>` sized to
+    // hold `B` (verified above). We own `op` exclusively.
+    unsafe {
+        ptr::write(op.buf_storage.get() as *mut B, buf);
+    }
+
+    Ok(Arc::pin(IoStatusBlock::from(PacketInner::FileOp { op })))
+}
+
+/// Helpers to access the `OpInner` inside a freshly-built `Packet`
+/// without going through the projection machinery (we need a
+/// `*mut OVERLAPPED` and the buffer back when classifying a sync
+/// success).
+fn op_in(packet: &Packet) -> &OpInner {
+    match packet.as_ref().data().project_ref() {
+        PacketInnerProj::FileOp { op } => op.get_ref(),
+        _ => unreachable!(),
+    }
+}
+
+impl RegisteredFile {
+    /// Mark the registration inactive; in-flight ops continue to
+    /// drive completions, but new `submit_*` calls error.
+    pub fn deactivate(&self) {
+        self.inner.active.store(false, Ordering::Release);
+    }
+
+    /// Rebind the user-visible event key.
+    ///
+    /// Intended for reactors that allocate the event key after
+    /// constructing the [`RegisteredFile`] — for example
+    /// [`async-io`](https://docs.rs/async-io)'s `Slab<Source>`
+    /// indexing (see `docs/named-pipe.design.md` §5.2).
+    ///
+    /// The new key applies to every completion the dispatcher emits
+    /// **after** the dispatcher's `Acquire` load of `user_key`
+    /// observes this `Release` store. There is no synchronisation
+    /// with completions already dequeued from the IOCP, nor with
+    /// completions whose `user_key` load happens-before the store;
+    /// those carry the previous key. Callers that need a strict
+    /// hand-off should drain pending events from
+    /// [`crate::Poller::wait`] before calling `set_user_key`.
+    pub fn set_user_key(&self, key: usize) {
+        self.inner.user_key.store(key, Ordering::Release);
+    }
+
+    /// Submit a `ReadFile` op. See module docs.
+    pub fn submit_read<B: StableBufMut>(&self, mut buf: B) -> Submission<B> {
+        if !self.inner.active.load(Ordering::Acquire) {
+            return Submission::Failed {
+                error: io::Error::new(io::ErrorKind::InvalidInput, "file removed from poller"),
+                buf,
+            };
+        }
+        let cap = buf.capacity();
+        // Win32 `ReadFile` takes a `u32` byte count. Reject buffers
+        // larger than `u32::MAX` early so the truncation does not
+        // silently short-read.
+        if cap > u32::MAX as usize {
+            return Submission::Failed {
+                error: io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "buffer capacity exceeds u32::MAX",
+                ),
+                buf,
+            };
+        }
+        let ptr = buf.as_mut_ptr();
+        let packet = match make_op_packet::<B>(
+            Arc::clone(&self.inner),
+            buf,
+            OpInterest {
+                readable: true,
+                writable: false,
+            },
+        ) {
+            Ok(p) => p,
+            Err((buf, error)) => return Submission::Failed { error, buf },
+        };
+        let overlapped = op_in(&packet).overlapped.get() as *mut OVERLAPPED;
+        let mut bytes_returned: u32 = 0;
+        // SAFETY: `self.inner.handle` is the kernel handle bound at
+        // registration time; `ptr` / `cap` describe the buffer we
+        // just moved into the packet (so it stays at this address
+        // for the kernel's use); `overlapped` is the per-op block.
+        let r = unsafe {
+            ReadFile(
+                self.inner.handle as _,
+                ptr,
+                cap as u32,
+                &mut bytes_returned as *mut _,
+                overlapped,
+            )
+        };
+        classify_submission::<B>(packet, r != FALSE, bytes_returned as usize)
+    }
+
+    /// Submit a `WriteFile` op. See module docs.
+    pub fn submit_write<B: StableBuf>(&self, buf: B) -> Submission<B> {
+        if !self.inner.active.load(Ordering::Acquire) {
+            return Submission::Failed {
+                error: io::Error::new(io::ErrorKind::InvalidInput, "file removed from poller"),
+                buf,
+            };
+        }
+        let len = buf.len();
+        // Win32 `WriteFile` takes a `u32` byte count. Reject buffers
+        // larger than `u32::MAX` early so the truncation does not
+        // silently short-write.
+        if len > u32::MAX as usize {
+            return Submission::Failed {
+                error: io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "buffer length exceeds u32::MAX",
+                ),
+                buf,
+            };
+        }
+        let ptr = buf.as_ptr();
+        let packet = match make_op_packet::<B>(
+            Arc::clone(&self.inner),
+            buf,
+            OpInterest {
+                readable: false,
+                writable: true,
+            },
+        ) {
+            Ok(p) => p,
+            Err((buf, error)) => return Submission::Failed { error, buf },
+        };
+        let overlapped = op_in(&packet).overlapped.get() as *mut OVERLAPPED;
+        let mut bytes_returned: u32 = 0;
+        // SAFETY: see `submit_read`.
+        let r = unsafe {
+            WriteFile(
+                self.inner.handle as _,
+                ptr,
+                len as u32,
+                &mut bytes_returned as *mut _,
+                overlapped,
+            )
+        };
+        classify_submission::<B>(packet, r != FALSE, bytes_returned as usize)
+    }
+
+    /// Submit a `ConnectNamedPipe` op. See module docs.
+    pub fn submit_connect_named_pipe(&self) -> Submission<()> {
+        if !self.inner.active.load(Ordering::Acquire) {
+            return Submission::Failed {
+                error: io::Error::new(io::ErrorKind::InvalidInput, "file removed from poller"),
+                buf: (),
+            };
+        }
+        // ConnectNamedPipe is the server-side accept; the typical
+        // follow-up is a `ReadFile`, so we mark it readable-only.
+        let packet = match make_op_packet::<()>(
+            Arc::clone(&self.inner),
+            (),
+            OpInterest {
+                readable: true,
+                writable: false,
+            },
+        ) {
+            Ok(p) => p,
+            Err((buf, error)) => return Submission::Failed { error, buf },
+        };
+        let overlapped = op_in(&packet).overlapped.get() as *mut OVERLAPPED;
+        // SAFETY: see `submit_read`.
+        let r = unsafe { ConnectNamedPipe(self.inner.handle as _, overlapped) };
+        if r != FALSE {
+            // Sync success. No completion will arrive.
+            return finish_sync_success::<()>(packet, 0);
+        }
+        // ConnectNamedPipe quirk: returns FALSE + ERROR_PIPE_CONNECTED
+        // when the client had already connected before the call.
+        let err = io::Error::last_os_error();
+        match err.raw_os_error().map(|e| e as u32) {
+            Some(ERROR_IO_PENDING) => {
+                // SAFETY: see `classify_submission`; the kernel
+                // owns one `Arc` strong ref for the lifetime of
+                // the in-flight op, reclaimed by the dispatcher.
+                std::mem::forget(packet.clone());
+                Submission::Pending(into_op_handle::<()>(packet))
+            }
+            Some(ERROR_PIPE_CONNECTED) => finish_sync_success::<()>(packet, 0),
+            _ => finish_sync_failure::<()>(packet, err),
+        }
+    }
+}
+
+fn classify_submission<B>(packet: Packet, sync_ok: bool, bytes: usize) -> Submission<B> {
+    if sync_ok {
+        return finish_sync_success::<B>(packet, bytes);
+    }
+    let err = io::Error::last_os_error();
+    match err.raw_os_error().map(|e| e as u32) {
+        Some(ERROR_IO_PENDING) => {
+            // SAFETY: the kernel kept our `OVERLAPPED` pointer (the
+            // syscall returned `ERROR_IO_PENDING`). We bump the
+            // packet `Arc` strong count here so the kernel
+            // logically owns one strong reference for the lifetime
+            // of the in-flight op. The IOCP completion dispatcher
+            // in `Poller::wait_deadline` reclaims that reference
+            // via `OverlappedEntry::into_file_op_packet` (which
+            // calls `Arc::from_raw` on the recovered packet
+            // pointer). The bump and the reclaim are paired one
+            // for one: every `Pending` submission produces exactly
+            // one completion entry.
+            std::mem::forget(packet.clone());
+            Submission::Pending(into_op_handle::<B>(packet))
+        }
+        _ => finish_sync_failure::<B>(packet, err),
+    }
+}
+
+fn into_op_handle<B>(packet: Packet) -> OpHandle<B> {
+    OpHandle {
+        packet,
+        _marker: PhantomData,
+    }
+}
+
+fn finish_sync_success<B>(packet: Packet, bytes: usize) -> Submission<B> {
+    // Take the buffer back out and discard the empty packet.
+    let buf = unsafe { take_buf_unchecked::<B>(&packet) };
+    Submission::Complete { bytes, buf }
+}
+
+fn finish_sync_failure<B>(packet: Packet, error: io::Error) -> Submission<B> {
+    let buf = unsafe { take_buf_unchecked::<B>(&packet) };
+    Submission::Failed { error, buf }
+}
+
+/// SAFETY: caller must ensure the buffer at `buf_storage` is still
+/// initialised (i.e. `taken == false`) and that no concurrent
+/// reader is racing on it (true for sync paths inside `submit_*`).
+unsafe fn take_buf_unchecked<B>(packet: &Packet) -> B {
+    let op = op_in(packet);
+    // SAFETY: see fn doc.
+    let buf: B = unsafe { ptr::read(op.buf_storage.get() as *const B) };
+    op.taken.store(true, Ordering::Release);
+    buf
+}
+
+#[cfg(test)]
+mod op_tests {
+    use super::*;
+
+    /// `OVERLAPPED` (the inner kernel block) must live at offset 0 of
+    /// `OpInner` so the kernel-written `lpOverlapped` pointer can be
+    /// cast straight back to `*mut OpInner`.
+    #[test]
+    fn op_inner_overlapped_at_offset_zero() {
+        assert_eq!(std::mem::offset_of!(OpInner, overlapped), 0);
+    }
+
+    /// Smoke test that an `OpInner` can be pinned in an `Arc` and the
+    /// raw-pointer round trip through `Pin::into_inner_unchecked` /
+    /// re-pinning works. `OpInner` is `!Unpin` (via `PhantomPinned`),
+    /// which is what we actually rely on.
+    #[test]
+    fn op_inner_round_trips_through_pinned_arc() {
+        let arc: Pin<Arc<OpInner>> = Arc::pin(OpInner::new());
+        // Round-trip via the unchecked pin API the IOCP path uses.
+        let raw = unsafe { Pin::into_inner_unchecked(arc) };
+        let _re_pinned: Pin<Arc<OpInner>> = unsafe { Pin::new_unchecked(raw) };
+    }
+
+    /// Calling `NOOP_VTABLE.drop_buf` on a zeroed buffer must be a
+    /// no-op and not panic.
+    #[test]
+    fn noop_vtable_drop_is_safe() {
+        let mut buf = [0u8; 32];
+        unsafe {
+            (NOOP_VTABLE.drop_buf)(buf.as_mut_ptr());
+        }
     }
 }

--- a/src/iocp/ntdll.rs
+++ b/src/iocp/ntdll.rs
@@ -1,0 +1,160 @@
+//! ntdll library bindings
+use std::{io, mem::transmute, sync::OnceLock};
+
+use windows_sys::{
+    Wdk::Foundation::OBJECT_ATTRIBUTES,
+    Win32::{
+        Foundation::{HANDLE, HMODULE, NTSTATUS},
+        System::{
+            LibraryLoader::{GetModuleHandleW, GetProcAddress},
+            IO::IO_STATUS_BLOCK,
+        },
+    },
+};
+
+macro_rules! define_ntdll_import {
+    (
+        $(
+            $(#[$attr:meta])*
+            fn $name:ident($($arg:ident: $arg_ty:ty),*) -> $ret:ty;
+        )*
+    ) => {
+        /// Imported functions from ntdll.dll.
+        #[allow(non_snake_case)]
+        pub(crate) struct NtdllImports {
+            $(
+                $(#[$attr])*
+                $name: unsafe extern "system" fn($($arg_ty),*) -> $ret,
+            )*
+        }
+
+        #[allow(non_snake_case)]
+        impl NtdllImports {
+            unsafe fn load(ntdll: HMODULE) -> io::Result<Self> {
+                $(
+                    #[allow(clippy::missing_transmute_annotations)]
+                    let $name = {
+                        const NAME: &str = concat!(stringify!($name), "\0");
+                        let addr = GetProcAddress(ntdll, NAME.as_ptr() as *const _);
+
+                        let addr = match addr {
+                            Some(addr) => addr,
+                            None => {
+                                #[cfg(feature = "tracing")]
+                                tracing::error!("Failed to load ntdll function {}", NAME);
+                                return Err(io::Error::last_os_error());
+                            },
+                        };
+
+                        transmute::<_, unsafe extern "system" fn($($arg_ty),*) -> $ret>(addr)
+                    };
+                )*
+
+                Ok(Self {
+                    $(
+                        $name,
+                    )*
+                })
+            }
+
+            $(
+                $(#[$attr])*
+                pub(crate) unsafe fn $name(&self, $($arg: $arg_ty),*) -> $ret {
+                    (self.$name)($($arg),*)
+                }
+            )*
+        }
+    };
+}
+
+define_ntdll_import! {
+    /// Cancels an ongoing I/O operation.
+    fn NtCancelIoFileEx(
+        FileHandle: HANDLE,
+        IoRequestToCancel: *mut IO_STATUS_BLOCK,
+        IoStatusBlock: *mut IO_STATUS_BLOCK
+    ) -> NTSTATUS;
+
+    /// Opens or creates a file handle.
+    #[allow(clippy::too_many_arguments)]
+    fn NtCreateFile(
+        FileHandle: *mut HANDLE,
+        DesiredAccess: u32,
+        ObjectAttributes: *mut OBJECT_ATTRIBUTES,
+        IoStatusBlock: *mut IO_STATUS_BLOCK,
+        AllocationSize: *mut i64,
+        FileAttributes: u32,
+        ShareAccess: u32,
+        CreateDisposition: u32,
+        CreateOptions: u32,
+        EaBuffer: *mut (),
+        EaLength: u32
+    ) -> NTSTATUS;
+
+    /// Runs an I/O control on a file handle.
+    ///
+    /// Practically equivalent to `ioctl`.
+    #[allow(clippy::too_many_arguments)]
+    fn NtDeviceIoControlFile(
+        FileHandle: HANDLE,
+        Event: HANDLE,
+        ApcRoutine: *mut (),
+        ApcContext: *mut (),
+        IoStatusBlock: *mut IO_STATUS_BLOCK,
+        IoControlCode: u32,
+        InputBuffer: *mut (),
+        InputBufferLength: u32,
+        OutputBuffer: *mut (),
+        OutputBufferLength: u32
+    ) -> NTSTATUS;
+
+    /// Converts `NTSTATUS` to a DOS error code.
+    fn RtlNtStatusToDosError(
+        Status: NTSTATUS
+    ) -> u32;
+}
+
+impl NtdllImports {
+    pub(crate) fn get() -> io::Result<&'static Self> {
+        macro_rules! s {
+            ($e:expr) => {{
+                $e as u16
+            }};
+        }
+
+        // ntdll.dll
+        static NTDLL_NAME: &[u16] = &[
+            s!('n'),
+            s!('t'),
+            s!('d'),
+            s!('l'),
+            s!('l'),
+            s!('.'),
+            s!('d'),
+            s!('l'),
+            s!('l'),
+            s!('\0'),
+        ];
+        static NTDLL_IMPORTS: OnceLock<io::Result<NtdllImports>> = OnceLock::new();
+
+        NTDLL_IMPORTS
+            .get_or_init(|| unsafe {
+                let ntdll = GetModuleHandleW(NTDLL_NAME.as_ptr() as *const _);
+
+                if ntdll.is_null() {
+                    #[cfg(feature = "tracing")]
+                    tracing::error!("Failed to load ntdll.dll");
+                    return Err(io::Error::last_os_error());
+                }
+
+                NtdllImports::load(ntdll)
+            })
+            .as_ref()
+            .map_err(|e| io::Error::from(e.kind()))
+    }
+
+    pub(crate) fn force_load() -> io::Result<()> {
+        Self::get()?;
+        Ok(())
+    }
+}

--- a/src/iocp/port.rs
+++ b/src/iocp/port.rs
@@ -10,13 +10,15 @@ use std::ops::Deref;
 use std::os::windows::io::{AsRawHandle, RawHandle};
 use std::pin::Pin;
 use std::ptr;
+use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
-use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
+use windows_sys::Win32::Foundation::{
+    CloseHandle, ERROR_INVALID_FUNCTION, HANDLE, INVALID_HANDLE_VALUE,
+};
 use windows_sys::Win32::Storage::FileSystem::SetFileCompletionNotificationModes;
 use windows_sys::Win32::System::Threading::INFINITE;
-use windows_sys::Win32::System::WindowsProgramming::FILE_SKIP_SET_EVENT_ON_HANDLE;
 use windows_sys::Win32::System::IO::{
     CreateIoCompletionPort, GetQueuedCompletionStatusEx, PostQueuedCompletionStatus, OVERLAPPED,
     OVERLAPPED_ENTRY,
@@ -65,6 +67,30 @@ pub(super) unsafe trait CompletionHandle: Deref + Sized {
     fn as_ptr(&self) -> *mut OVERLAPPED;
 }
 
+/// Byte offset from a per-op `OVERLAPPED` block back to the start of
+/// the owning `IoStatusBlock<T>`.
+///
+/// Used to recover the containing `Packet` from the raw
+/// `lpOverlapped` pointer that the kernel places into each
+/// `OVERLAPPED_ENTRY`.
+pub(super) trait FileOverlapped {
+    /// Offset from the per-op `OVERLAPPED` (inside `OpInner.overlapped`)
+    /// to the start of `IoStatusBlock<T>` for the `FileOp` variant.
+    fn file_op_offset() -> usize;
+}
+
+/// Recovers the owning `IoStatusBlock<T>` from a file completion's
+/// `OVERLAPPED_ENTRY`.
+///
+/// # Safety
+///
+/// The `lpOverlapped` pointer in the entry must point into a valid
+/// `IoStatusBlock<T>` that has not been freed.
+pub(super) unsafe trait FileCompletionHandle {
+    /// Recover the owner from a `FileOp` completion.
+    fn file_op_done(entry: &OVERLAPPED_ENTRY) -> Self;
+}
+
 unsafe impl<T: Completion> CompletionHandle for Pin<&T> {
     type Completion = T;
 
@@ -105,10 +131,42 @@ unsafe impl<T: Completion> CompletionHandle for Pin<Arc<T>> {
     }
 }
 
+unsafe impl<T: FileOverlapped> FileCompletionHandle for Pin<&T> {
+    fn file_op_done(entry: &OVERLAPPED_ENTRY) -> Self {
+        let overlapped_ptr = entry.lpOverlapped;
+        let offset = T::file_op_offset();
+        // SAFETY: the `OpInner` whose `OVERLAPPED` produced this entry is
+        // held alive by the user's `OpHandle` (or, in the leaked case,
+        // outlives the program); the borrow lifetime is the caller's
+        // problem.
+        unsafe { Pin::new_unchecked(&*((overlapped_ptr as *mut u8).sub(offset) as *const T)) }
+    }
+}
+
+unsafe impl<T: FileOverlapped> FileCompletionHandle for Pin<Arc<T>> {
+    fn file_op_done(entry: &OVERLAPPED_ENTRY) -> Self {
+        let overlapped_ptr = entry.lpOverlapped;
+        let offset = T::file_op_offset();
+        // The submitter (`classify_submission` in `iocp::mod`) bumped the `Arc`
+        // strong count via `mem::forget(packet.clone())` when the op
+        // entered the `Pending` state, so the kernel logically owns
+        // one strong reference. Reclaim that reference here via a
+        // plain `Arc::from_raw` (no extra increment). Mirrors the
+        // bump/reclaim invariant in `docs/named-pipe.design.md`
+        // §3.4.
+        unsafe {
+            let raw = (overlapped_ptr as *const u8).sub(offset) as *const T;
+            Pin::new_unchecked(Arc::from_raw(raw))
+        }
+    }
+}
 /// A handle to the I/O completion port.
 pub(super) struct IoCompletionPort<T> {
     /// The underlying handle.
     handle: HANDLE,
+
+    /// The completion key generator.
+    key_gen: CompletionKeyGenerator,
 
     /// We own the status block.
     _marker: PhantomData<T>,
@@ -144,7 +202,7 @@ impl<T> fmt::Debug for IoCompletionPort<T> {
     }
 }
 
-impl<T: CompletionHandle> IoCompletionPort<T> {
+impl<T: CompletionHandle + FileCompletionHandle> IoCompletionPort<T> {
     /// Create a new I/O completion port.
     pub(super) fn new(threads: usize) -> io::Result<Self> {
         let handle = unsafe {
@@ -161,34 +219,51 @@ impl<T: CompletionHandle> IoCompletionPort<T> {
         } else {
             Ok(Self {
                 handle,
+                key_gen: Default::default(),
                 _marker: PhantomData,
             })
         }
     }
 
     /// Register a handle with this I/O completion port.
+    ///
+    /// `notification_flags` is the value passed to
+    /// [`SetFileCompletionNotificationModes`] after registration. Pass `0`
+    /// to skip the call entirely. `ERROR_INVALID_FUNCTION` from
+    /// `SetFileCompletionNotificationModes` is treated as a non-fatal
+    /// no-op (some device types do not support the API).
     pub(super) fn register(
         &self,
         handle: &impl AsRawHandle, // TODO change to AsHandle
-        skip_set_event_on_handle: bool,
+        notification_flags: u8,
+        kind: CompletionKeyType,
     ) -> io::Result<()> {
         let handle = handle.as_raw_handle();
 
-        let result =
-            unsafe { CreateIoCompletionPort(handle as _, self.handle, handle as usize, 0) };
+        let result = unsafe {
+            CreateIoCompletionPort(
+                handle as _,
+                self.handle,
+                CompletionKey::new(kind, &self.key_gen).into(),
+                0,
+            )
+        };
 
         if result.is_null() {
             return Err(io::Error::last_os_error());
         }
 
-        if skip_set_event_on_handle {
-            // Set the skip event on handle.
-            let result = unsafe {
-                SetFileCompletionNotificationModes(handle as _, FILE_SKIP_SET_EVENT_ON_HANDLE as _)
-            };
+        if notification_flags != 0 {
+            // SAFETY: `handle` was just successfully attached to an IOCP,
+            // so it is a valid open handle for the lifetime of this call.
+            let result =
+                unsafe { SetFileCompletionNotificationModes(handle as _, notification_flags) };
 
             if result == 0 {
-                return Err(io::Error::last_os_error());
+                let err = io::Error::last_os_error();
+                if err.raw_os_error() != Some(ERROR_INVALID_FUNCTION as i32) {
+                    return Err(err);
+                }
             }
         }
 
@@ -257,7 +332,7 @@ impl<T: CompletionHandle> IoCompletionPort<T> {
 
 /// An `OVERLAPPED_ENTRY` resulting from an I/O completion port.
 #[repr(transparent)]
-pub(super) struct OverlappedEntry<T: CompletionHandle> {
+pub(super) struct OverlappedEntry<T: CompletionHandle + FileCompletionHandle> {
     /// The underlying entry.
     entry: OVERLAPPED_ENTRY,
 
@@ -265,16 +340,60 @@ pub(super) struct OverlappedEntry<T: CompletionHandle> {
     _marker: PhantomData<T>,
 }
 
-impl<T: CompletionHandle> fmt::Debug for OverlappedEntry<T> {
+impl<T: CompletionHandle + FileCompletionHandle> fmt::Debug for OverlappedEntry<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("OverlappedEntry { .. }")
     }
 }
 
-impl<T: CompletionHandle> OverlappedEntry<T> {
+impl<T: CompletionHandle + FileCompletionHandle> OverlappedEntry<T> {
     /// Convert into the completion packet.
     pub(super) fn into_packet(self) -> T {
         let packet = unsafe { self.packet() };
+        std::mem::forget(self);
+        packet
+    }
+
+    /// Get the number of bytes transferred by the I/O operation.
+    pub(super) fn bytes_transferred(&self) -> u32 {
+        self.entry.dwNumberOfBytesTransferred
+    }
+
+    /// Returns `true` if this entry was posted for a file handle
+    /// (registered via `register_file`).
+    pub(super) fn is_file_completion(&self) -> bool {
+        CompletionKey::from(self.entry.lpCompletionKey).is_file()
+    }
+
+    /// Read the NTSTATUS code from the embedded `OVERLAPPED.Internal`
+    /// field of this completion. The value is meaningful only for file
+    /// completions; sockets / waitables encode their status separately.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure `self.entry.lpOverlapped` points to a live
+    /// `OVERLAPPED` block (true for any not-yet-consumed entry).
+    pub(super) unsafe fn nt_status_raw(&self) -> i32 {
+        // SAFETY: caller-asserted.
+        unsafe { (*self.entry.lpOverlapped).Internal as i32 }
+    }
+
+    /// Convert into the owning `T` using the `FileOp` offset path.
+    ///
+    /// Unlike [`into_packet`](Self::into_packet), the `lpOverlapped`
+    /// here does **not** point to the start of the packet; it points to
+    /// an inner `OVERLAPPED` field inside `OpInner`.
+    ///
+    /// # Safety
+    ///
+    /// Must be called at most once per entry. The `lpOverlapped` must
+    /// belong to a live `FileOp` packet.
+    pub(super) fn into_file_op_packet(self) -> T {
+        assert!(
+            self.is_file_completion(),
+            "This is not a file-op completion packet"
+        );
+        let packet = T::file_op_done(&self.entry);
         std::mem::forget(self);
         packet
     }
@@ -292,8 +411,151 @@ impl<T: CompletionHandle> OverlappedEntry<T> {
     }
 }
 
-impl<T: CompletionHandle> Drop for OverlappedEntry<T> {
+impl<T: CompletionHandle + FileCompletionHandle> Drop for OverlappedEntry<T> {
     fn drop(&mut self) {
-        drop(unsafe { self.packet() });
+        // Both file-op and socket/waitable/wakeup entries transfer one
+        // `Arc` strong reference into the kernel at submit time. If the
+        // dispatcher consumes the entry through `into_packet` /
+        // `into_file_op_packet`, those helpers `mem::forget` the entry
+        // and this `Drop` does not run. Otherwise (panic, early
+        // return) we reclaim the kernel's ref here so the allocation
+        // is not leaked.
+        if self.is_file_completion() {
+            drop(unsafe { T::file_op_done(&self.entry) });
+        } else {
+            drop(unsafe { self.packet() });
+        }
+    }
+}
+
+/// Distinguishes the kind of handle a completion key was generated for.
+///
+/// IOCP itself does not require completion keys to be unique per handle: the
+/// real per-completion routing is done through `lpOverlapped` (which points
+/// back to the owning `Packet`). We use the high bit of the key purely as a
+/// fast classifier so the dispatcher can choose the correct conversion path
+/// when a completion arrives:
+///
+/// - high bit clear → socket / waitable / wakeup completion → recover the
+///   `Packet` via `T::from_ptr(lpOverlapped)`.
+/// - high bit set   → file-op completion (registered via
+///   `register_file`) → recover via the per-op `file_op_offset()`.
+///
+/// [`OverlappedEntry::into_packet`]: crate::iocp::OverlappedEntry::into_packet
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CompletionKeyType {
+    Socket,
+    FileOp,
+}
+
+/// Per-poller completion key.
+///
+/// The low 31 (or 63) bits are a monotonically increasing counter that wraps
+/// around if exhausted. The counter value is **not used for handle
+/// identification**:
+///
+/// - For sockets and waitables, it is purely informational (handle routing
+///   uses `lpOverlapped`). Counter wrap-around is therefore harmless.
+/// - For files the counter is also not used for routing, but the **high bit
+///   is** — it tells the dispatcher to use the file completion path.
+///
+/// Key value `0` is reserved for IOCP-internal packets (notify / wakeup /
+/// custom user packets posted via `PostQueuedCompletionStatus` with key `0`).
+///
+/// 31 bits of headroom is more than sufficient on 32-bit Windows, since
+/// handle exhaustion will hit long before the counter wraps.
+#[repr(transparent)]
+struct CompletionKey(usize);
+
+#[derive(Debug)]
+struct CompletionKeyGenerator {
+    next_default_key: AtomicUsize,
+    next_file_key: AtomicUsize,
+}
+
+impl Default for CompletionKeyGenerator {
+    fn default() -> Self {
+        Self {
+            next_default_key: AtomicUsize::new(1), // 0 reserved for default iocp packet
+            next_file_key: AtomicUsize::new(1usize << (usize::BITS - 1)), // Initialize with high bit set
+        }
+    }
+}
+
+impl CompletionKey {
+    const HIGH_BIT: usize = 1usize << (usize::BITS - 1); // 0x8000_0000_0000_0000 on 64-bit
+    /// Reserved class bits. Counter values must avoid these.
+    const CLASS_MASK: usize = Self::HIGH_BIT;
+    const COUNTER_MASK: usize = !Self::CLASS_MASK; // 0x7FFF_FFFF_FFFF_FFFF on 64-bit
+    pub(super) fn new(kind: CompletionKeyType, gen: &CompletionKeyGenerator) -> Self {
+        match kind {
+            CompletionKeyType::FileOp => {
+                // FileOp keys live in the HIGH_BIT bucket. The counter
+                // portion only needs to be unique \u2014 it's not used for
+                // routing. Wraps within the bucket on overflow.
+                let key = loop {
+                    let current = gen.next_file_key.load(std::sync::atomic::Ordering::Relaxed);
+                    let next = if current == (Self::HIGH_BIT | Self::COUNTER_MASK) {
+                        Self::HIGH_BIT
+                    } else {
+                        current + 1
+                    };
+
+                    match gen.next_file_key.compare_exchange_weak(
+                        current,
+                        next,
+                        std::sync::atomic::Ordering::Relaxed,
+                        std::sync::atomic::Ordering::Relaxed,
+                    ) {
+                        Ok(_) => break current,
+                        Err(_) => continue,
+                    }
+                };
+                Self(key)
+            }
+            CompletionKeyType::Socket => {
+                // For default keys, ensure the counter never exceeds
+                // COUNTER_MASK. If it would overflow, wrap back to 1.
+                let key = loop {
+                    let current = gen
+                        .next_default_key
+                        .load(std::sync::atomic::Ordering::Relaxed);
+                    let next = if current >= Self::COUNTER_MASK {
+                        1
+                    } else {
+                        current + 1
+                    };
+
+                    match gen.next_default_key.compare_exchange_weak(
+                        current,
+                        next,
+                        std::sync::atomic::Ordering::Relaxed,
+                        std::sync::atomic::Ordering::Relaxed,
+                    ) {
+                        Ok(_) => break current,
+                        Err(_) => continue,
+                    }
+                };
+
+                Self(key)
+            }
+        }
+    }
+
+    /// Returns `true` if the key belongs to a file handle (high bit set).
+    pub(super) fn is_file(&self) -> bool {
+        (self.0 & Self::HIGH_BIT) != 0
+    }
+}
+
+impl From<CompletionKey> for usize {
+    fn from(key: CompletionKey) -> Self {
+        key.0
+    }
+}
+
+impl From<usize> for CompletionKey {
+    fn from(key: usize) -> Self {
+        Self(key)
     }
 }

--- a/src/os/iocp.rs
+++ b/src/os/iocp.rs
@@ -1,5 +1,9 @@
 //! Functionality that is only available for IOCP-based platforms.
 
+pub use crate::iocp::{
+    buf::{StableBuf, StableBufMut},
+    OpHandle, RegisteredFile, Submission,
+};
 pub use crate::sys::CompletionPacket;
 
 use super::__private::PollerSealed;
@@ -251,3 +255,116 @@ pub trait AsWaitable: AsHandle {
 }
 
 impl<T: AsHandle + ?Sized> AsWaitable for T {}
+
+/// Extension trait for [`Poller`] that adds file-handle support on
+/// IOCP-based platforms.
+///
+/// File handles registered through this trait drive overlapped I/O via
+/// the [`RegisteredFile`] / [`OpHandle`] / [`Submission`] surface. See
+/// `docs/named-pipe.design.md` for the design rationale.
+///
+/// [`Poller`]: crate::Poller
+pub trait PollerIocpFileExt: PollerSealed {
+    /// Register a file handle for IOCP-based overlapped I/O.
+    ///
+    /// `key` follows the same convention as
+    /// [`Poller::add`](crate::Poller::add): it is the user-chosen
+    /// identifier mirrored into [`Event::key`] of every completion
+    /// emitted for ops on this file. A reactor (e.g. `async-io`) keys
+    /// its waker registry by this value.
+    ///
+    /// The returned [`RegisteredFile`] is cheaply cloneable and is the
+    /// entry point for [`RegisteredFile::submit_read`],
+    /// [`RegisteredFile::submit_write`] and
+    /// [`RegisteredFile::submit_connect_named_pipe`]. Each pending
+    /// submission produces an [`OpHandle`] that owns the operation's
+    /// lifecycle: drive [`crate::Poller::wait`] until the matching
+    /// completion event arrives, then call
+    /// [`OpHandle::is_complete`] / [`OpHandle::take`].
+    ///
+    /// Read submissions emit `Event { key, readable: true, .. }` on
+    /// completion; writes emit `writable: true`;
+    /// `submit_connect_named_pipe` emits `readable: true` (the typical
+    /// follow-up is a server-side read).
+    ///
+    /// The handle can be any Win32 handle opened with
+    /// `FILE_FLAG_OVERLAPPED`, such as files, named/anonymous pipes,
+    /// mailslots, serial ports, or other communication devices.
+    ///
+    /// # Safety
+    ///
+    /// The caller must uphold all of the following:
+    ///
+    /// - The handle was opened with `FILE_FLAG_OVERLAPPED`. Submitting
+    ///   overlapped I/O against a synchronous handle is undefined
+    ///   behaviour at the Win32 layer.
+    /// - The handle is not already attached to another
+    ///   `IoCompletionPort`. Win32 forbids re-association and the
+    ///   second `CreateIoCompletionPort` call will fail; the
+    ///   safety hazard is silently sharing completions across two
+    ///   pollers.
+    /// - The handle outlives every [`OpHandle`] created from this
+    ///   registration **and** every in-flight op has produced its
+    ///   completion event before the handle is closed. Closing the
+    ///   handle while ops are pending in the kernel is sound
+    ///   (Windows cancels them and posts completions), but the
+    ///   caller must still drain those completions via
+    ///   [`crate::Poller::wait`] to release the per-op packet
+    ///   allocations.
+    ///
+    /// # Resource leaks on [`crate::Poller`] drop
+    ///
+    /// Each pending submission holds a reference-counted packet that
+    /// the IOCP dispatcher reclaims when it observes the matching
+    /// completion. If the [`crate::Poller`] is dropped while ops are
+    /// still pending, the dispatcher never runs again and the
+    /// per-op packet (including the user-supplied buffer) leaks.
+    /// There is no use-after-free — the kernel still owns a
+    /// `Pin<Arc<…>>` strong reference — but the memory is not
+    /// recovered. Callers that need clean shutdown should
+    /// [`crate::Poller::wait`] until every in-flight op has
+    /// completed (typically after closing the underlying handle to
+    /// trigger cancellation) before dropping the [`crate::Poller`].
+    unsafe fn register_file(
+        &self,
+        file: impl AsRawFileHandle,
+        key: usize,
+    ) -> io::Result<RegisteredFile>;
+}
+/// A type that represents a raw file handle.
+pub trait AsRawFileHandle {
+    /// Returns the raw handle of this file.
+    fn as_raw_handle(&self) -> RawHandle;
+}
+
+impl AsRawFileHandle for RawHandle {
+    fn as_raw_handle(&self) -> RawHandle {
+        *self
+    }
+}
+
+impl<T: AsRawHandle + ?Sized> AsRawFileHandle for &T {
+    fn as_raw_handle(&self) -> RawHandle {
+        AsRawHandle::as_raw_handle(*self)
+    }
+}
+
+/// A type that represents a file handle.
+pub trait AsFileHandle: AsHandle {
+    /// Returns the raw handle of this file.
+    fn as_file(&self) -> BorrowedHandle<'_> {
+        self.as_handle()
+    }
+}
+
+impl<T: AsHandle + ?Sized> AsFileHandle for T {}
+
+impl PollerIocpFileExt for Poller {
+    unsafe fn register_file(
+        &self,
+        file: impl AsRawFileHandle,
+        key: usize,
+    ) -> io::Result<RegisteredFile> {
+        self.poller.register_file(file.as_raw_handle(), key)
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,123 @@
+//! Shared helpers for Windows IOCP file-handle tests.
+//!
+//! Copied from `tests/windows_overlapped.rs` so that the new v2 test
+//! suite (`tests/file_concurrent.rs`, `tests/file_lifetime.rs`) does
+//! not have to depend on the legacy test file. Step 4 of the redesign
+//! will delete the duplicates in `windows_overlapped.rs` and switch
+//! that file over to `mod common;`.
+//!
+//! See `docs/named-pipe.implement.checklist.md` Step 3.1.
+
+#![cfg(windows)]
+#![allow(dead_code)] // not all helpers are used by every test crate
+
+use std::ffi::OsStr;
+use std::fs::OpenOptions;
+use std::io;
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::fs::OpenOptionsExt;
+use std::os::windows::io::{FromRawHandle, IntoRawHandle, OwnedHandle};
+
+use windows_sys::Win32::{Foundation as wf, Storage::FileSystem as wfs, System::Pipes as wps};
+
+/// Detect whether the test process is running under Wine.
+///
+/// Wine's IOCP / NtReadFile / NtCancelIoFileEx implementations are not
+/// complete enough to drive these tests reliably; the CI `wine` job
+/// uses this helper to skip integration tests that depend on the new
+/// file-handle API. Returns `true` iff `ntdll.dll!wine_get_version`
+/// resolves.
+pub fn is_wine() -> bool {
+    use windows_sys::Win32::System::LibraryLoader::{GetModuleHandleA, GetProcAddress};
+    unsafe {
+        let ntdll = GetModuleHandleA(c"ntdll.dll".as_ptr().cast());
+        if ntdll.is_null() {
+            return false;
+        }
+        GetProcAddress(ntdll, c"wine_get_version".as_ptr().cast()).is_some()
+    }
+}
+
+/// Skip the current test (return early, printing a notice) when
+/// running under Wine.
+#[macro_export]
+macro_rules! skip_on_wine {
+    () => {
+        if $crate::common::is_wine() {
+            eprintln!("skipping on wine: {}", module_path!());
+            return;
+        }
+    };
+}
+
+/// Create a server-side named pipe handle in byte / overlapped mode.
+pub fn new_named_pipe<A: AsRef<OsStr>>(addr: A) -> io::Result<OwnedHandle> {
+    let fname = addr
+        .as_ref()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    let handle = unsafe {
+        let raw_handle = wps::CreateNamedPipeW(
+            fname.as_ptr(),
+            wfs::PIPE_ACCESS_DUPLEX | wfs::FILE_FLAG_OVERLAPPED,
+            wps::PIPE_TYPE_BYTE | wps::PIPE_READMODE_BYTE | wps::PIPE_WAIT,
+            1,
+            4096,
+            4096,
+            0,
+            std::ptr::null_mut(),
+        );
+
+        if raw_handle == wf::INVALID_HANDLE_VALUE {
+            return Err(io::Error::last_os_error());
+        }
+
+        OwnedHandle::from_raw_handle(raw_handle as _)
+    };
+
+    Ok(handle)
+}
+
+/// Allocate a fresh pipe name and create the server end.
+pub fn server() -> (OwnedHandle, String) {
+    let num: u64 = fastrand::u64(..);
+    let name = format!(r"\\.\pipe\my-pipe-{}", num);
+    let pipe = new_named_pipe(&name).unwrap();
+    (pipe, name)
+}
+
+/// Open the client end of an existing named pipe in overlapped mode.
+pub fn client(name: &str) -> io::Result<OwnedHandle> {
+    let mut opts = OpenOptions::new();
+    opts.read(true)
+        .write(true)
+        .custom_flags(wfs::FILE_FLAG_OVERLAPPED);
+    let file = opts.open(name)?;
+    unsafe { Ok(OwnedHandle::from_raw_handle(file.into_raw_handle())) }
+}
+
+/// Convenience: server + matched client.
+pub fn pipe() -> (OwnedHandle, OwnedHandle) {
+    let (server, name) = server();
+    let client = client(&name).unwrap();
+    (server, client)
+}
+
+/// Drive `poller.wait` until `handle.is_complete()` reports `true`,
+/// or panic if the timeout elapses first.
+pub fn wait_for_handle<B>(
+    handle: &polling::os::iocp::OpHandle<B>,
+    poller: &polling::Poller,
+    events: &mut polling::Events,
+    timeout: std::time::Duration,
+) {
+    let deadline = std::time::Instant::now() + timeout;
+    while !handle.is_complete() {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            panic!("timeout waiting for OpHandle completion");
+        }
+        poller.wait(events, Some(remaining)).unwrap();
+    }
+}

--- a/tests/file_concurrent.rs
+++ b/tests/file_concurrent.rs
@@ -1,0 +1,555 @@
+//! Concurrency tests for the v2 IOCP file-handle submission API.
+//!
+//! Spec: `docs/named-pipe.implement.checklist.md` Step 3.2 / 3.4 / 7.
+//!
+//! Step 7 reworked the API: `OpHandle` owns the completion lifecycle
+//! directly. There is no `FileCompletion` token and no
+//! `Events::*_file_completions` channel any more — the dispatcher
+//! parks the result on the originating `OpHandle` and emits a normal
+//! `Event { key, readable, writable }` (Step 7b). The user discovers
+//! completion via `is_complete` / `try_take` / `take` and routes the
+//! wake through the reactor that owns the key.
+
+#![cfg(windows)]
+
+mod common;
+
+use std::os::windows::io::AsRawHandle;
+use std::time::{Duration, Instant};
+
+use polling::os::iocp::{OpHandle, PollerIocpFileExt, Submission};
+use polling::{Events, Poller};
+
+use windows_sys::Win32::Foundation::ERROR_OPERATION_ABORTED;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Drive `poller.wait` until every handle in `ops` (slot is `Some`)
+/// has its completion published, draining each `Some` slot via `take`
+/// and pushing `(n, B)` into `out` (or `Err` for cancelled ops).
+fn drain_handles<B>(
+    poller: &Poller,
+    events: &mut Events,
+    ops: &mut [Option<OpHandle<B>>],
+    out: &mut Vec<std::io::Result<(usize, B)>>,
+) {
+    let deadline = Instant::now() + TEST_TIMEOUT;
+    loop {
+        let mut all_taken = true;
+        for slot in ops.iter_mut() {
+            if let Some(op) = slot {
+                if op.is_complete() {
+                    let op = slot.take().unwrap();
+                    let (res, buf) = op.take();
+                    out.push(res.map(|n| (n, buf)));
+                } else {
+                    all_taken = false;
+                }
+            }
+        }
+        if all_taken {
+            return;
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            panic!(
+                "timeout waiting for {} pending op(s)",
+                ops.iter().filter(|s| s.is_some()).count()
+            );
+        }
+        poller.wait(events, Some(remaining)).unwrap();
+    }
+}
+
+#[test]
+fn async_path_still_returns_pending() {
+    skip_on_wine!();
+    let (server, _client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+
+    let buf = Vec::<u8>::with_capacity(64);
+    let op = match server_reg.submit_read(buf) {
+        Submission::Pending(op) => op,
+        Submission::Complete { .. } => panic!("expected Pending on empty pipe"),
+        Submission::Failed { error, .. } => panic!("read failed: {error}"),
+    };
+
+    op.cancel().unwrap();
+    let mut events = Events::new();
+    common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+    let _ = op.take();
+}
+
+#[test]
+fn sync_success_returns_complete_variant() {
+    skip_on_wine!();
+    let (server, client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+    let client_reg = unsafe { poller.register_file(client.as_raw_handle(), 2).unwrap() };
+
+    match client_reg.submit_write(b"hello".to_vec()) {
+        Submission::Complete { bytes, .. } => assert_eq!(bytes, 5),
+        Submission::Pending(op) => {
+            let mut events = Events::new();
+            common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+            let (res, _) = op.take();
+            let n = res.unwrap();
+            assert_eq!(n, 5);
+        }
+        Submission::Failed { error, .. } => panic!("write failed: {error}"),
+    }
+
+    let buf = Vec::<u8>::with_capacity(16);
+    match server_reg.submit_read(buf) {
+        Submission::Complete { bytes, buf } => {
+            assert_eq!(bytes, 5);
+            let slice = unsafe { std::slice::from_raw_parts(buf.as_ptr(), bytes) };
+            assert_eq!(slice, b"hello");
+        }
+        Submission::Pending(_) => panic!("expected sync Complete when data was buffered"),
+        Submission::Failed { error, .. } => panic!("read failed: {error}"),
+    }
+}
+
+#[test]
+fn two_concurrent_writes_distinguish_completions() {
+    skip_on_wine!();
+    let (server, client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+    let client_reg = unsafe { poller.register_file(client.as_raw_handle(), 2).unwrap() };
+
+    let payload_a = vec![b'A'; 5000];
+    let payload_b = vec![b'B'; 6000];
+
+    let op_a = match client_reg.submit_write(payload_a) {
+        Submission::Pending(op) => op,
+        other => panic!("expected Pending for write A, got {other:?}"),
+    };
+    let op_b = match client_reg.submit_write(payload_b) {
+        Submission::Pending(op) => op,
+        other => panic!("expected Pending for write B, got {other:?}"),
+    };
+
+    // Drain on the server end so the kernel can complete the writes.
+    let mut events = Events::new();
+    let mut completions = 0usize;
+    let deadline = Instant::now() + TEST_TIMEOUT;
+    while completions < 11_000 {
+        let buf = Vec::<u8>::with_capacity(16 * 1024);
+        match server_reg.submit_read(buf) {
+            Submission::Complete { bytes, .. } => completions += bytes,
+            Submission::Pending(op) => {
+                common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+                let (res, _) = op.take();
+                let n = res.unwrap();
+                completions += n;
+            }
+            Submission::Failed { error, .. } => panic!("server read failed: {error}"),
+        }
+    }
+
+    // Both writes should have completion entries posted; drain them.
+    while !(op_a.is_complete() && op_b.is_complete()) {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            panic!("write completions did not arrive in time");
+        }
+        poller.wait(&mut events, Some(remaining)).unwrap();
+    }
+
+    let (res, ba) = op_a.take();
+    let na = res.unwrap();
+    let (res, bb) = op_b.take();
+    let nb = res.unwrap();
+    assert_eq!(na, 5000);
+    assert_eq!(nb, 6000);
+    assert!(ba.iter().all(|&b| b == b'A'));
+    assert!(bb.iter().all(|&b| b == b'B'));
+}
+
+#[test]
+fn two_concurrent_reads_dispatch_correctly() {
+    skip_on_wine!();
+    let (server, client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+    let client_reg = unsafe { poller.register_file(client.as_raw_handle(), 2).unwrap() };
+
+    let op1 = match server_reg.submit_read(Vec::<u8>::with_capacity(4)) {
+        Submission::Pending(op) => op,
+        other => panic!("expected Pending, got {other:?}"),
+    };
+    let op2 = match server_reg.submit_read(Vec::<u8>::with_capacity(4)) {
+        Submission::Pending(op) => op,
+        other => panic!("expected Pending, got {other:?}"),
+    };
+
+    for payload in [b"AAAA".to_vec(), b"BBBB".to_vec()] {
+        match client_reg.submit_write(payload) {
+            Submission::Complete { bytes, .. } => assert_eq!(bytes, 4),
+            Submission::Pending(op) => {
+                let mut events = Events::new();
+                common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+                let _ = op.take().0.unwrap();
+            }
+            Submission::Failed { error, .. } => panic!("write failed: {error}"),
+        }
+    }
+
+    let mut ops = [Some(op1), Some(op2)];
+    let mut got = Vec::new();
+    let mut events = Events::new();
+    drain_handles(&poller, &mut events, &mut ops, &mut got);
+
+    assert_eq!(got.len(), 2);
+    for r in &got {
+        let (n, buf) = r.as_ref().unwrap();
+        assert_eq!(*n, 4);
+        let slice = unsafe { std::slice::from_raw_parts(buf.as_ptr(), *n) };
+        assert!(slice == b"AAAA" || slice == b"BBBB", "got {slice:?}");
+    }
+}
+
+#[test]
+fn mixed_read_write_concurrent() {
+    skip_on_wine!();
+    let (server, client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+    let client_reg = unsafe { poller.register_file(client.as_raw_handle(), 2).unwrap() };
+
+    let read_op = match server_reg.submit_read(Vec::<u8>::with_capacity(8)) {
+        Submission::Pending(op) => op,
+        other => panic!("expected Pending read, got {other:?}"),
+    };
+
+    let write_outcome = server_reg.submit_write(b"SVR->CLI".to_vec());
+
+    match client_reg.submit_write(b"CLI->SVR".to_vec()) {
+        Submission::Complete { bytes, .. } => assert_eq!(bytes, 8),
+        Submission::Pending(op) => {
+            let mut events = Events::new();
+            common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+            let _ = op.take().0.unwrap();
+        }
+        Submission::Failed { error, .. } => panic!("client write failed: {error}"),
+    }
+
+    let mut events = Events::new();
+    common::wait_for_handle(&read_op, &poller, &mut events, TEST_TIMEOUT);
+    let (res, buf) = read_op.take();
+    let n = res.unwrap();
+    assert_eq!(n, 8);
+    let slice = unsafe { std::slice::from_raw_parts(buf.as_ptr(), n) };
+    assert_eq!(slice, b"CLI->SVR");
+
+    if let Submission::Pending(op) = write_outcome {
+        let _ = op.cancel();
+        common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+        let _ = op.take();
+    }
+}
+
+#[test]
+fn cancel_pending_read_returns_aborted() {
+    skip_on_wine!();
+    let (server, _client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+
+    let op = match server_reg.submit_read(Vec::<u8>::with_capacity(8)) {
+        Submission::Pending(op) => op,
+        other => panic!("expected Pending, got {other:?}"),
+    };
+    op.cancel().unwrap();
+
+    let mut events = Events::new();
+    common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+    let err = op
+        .take()
+        .0
+        .expect_err("cancelled op should report an error");
+    assert_eq!(
+        err.raw_os_error(),
+        Some(ERROR_OPERATION_ABORTED as i32),
+        "expected ERROR_OPERATION_ABORTED, got {err:?}"
+    );
+}
+
+#[test]
+fn cancel_after_completion_is_noop() {
+    skip_on_wine!();
+    let (server, client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+    let client_reg = unsafe { poller.register_file(client.as_raw_handle(), 2).unwrap() };
+
+    let op = match server_reg.submit_read(Vec::<u8>::with_capacity(4)) {
+        Submission::Pending(op) => op,
+        other => panic!("expected Pending, got {other:?}"),
+    };
+
+    let _ = client_reg.submit_write(b"DATA".to_vec());
+
+    let mut events = Events::new();
+    common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+
+    // Cancel after completion — must not panic / UAF, must return Ok.
+    op.cancel().unwrap();
+
+    let (res, _) = op.take();
+    let n = res.unwrap();
+    assert_eq!(n, 4);
+}
+
+#[test]
+fn cancel_one_of_many_does_not_affect_siblings() {
+    skip_on_wine!();
+    let (server, client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+    let client_reg = unsafe { poller.register_file(client.as_raw_handle(), 2).unwrap() };
+
+    let mut ops: Vec<Option<OpHandle<Vec<u8>>>> = (0..3)
+        .map(
+            |_| match server_reg.submit_read(Vec::<u8>::with_capacity(4)) {
+                Submission::Pending(op) => Some(op),
+                other => panic!("expected Pending, got {other:?}"),
+            },
+        )
+        .collect();
+
+    ops[1].as_ref().unwrap().cancel().unwrap();
+
+    let _ = client_reg.submit_write(b"AAAA".to_vec());
+    let _ = client_reg.submit_write(b"CCCC".to_vec());
+
+    let mut events = Events::new();
+    let mut results = Vec::new();
+    drain_handles(&poller, &mut events, &mut ops, &mut results);
+
+    assert_eq!(results.len(), 3);
+    let mut sibling_ok = 0;
+    let mut middle_aborted = false;
+    for (i, r) in results.into_iter().enumerate() {
+        match r {
+            Ok((n, _)) => {
+                assert_ne!(i, 1, "cancelled middle op should not have completed Ok");
+                assert_eq!(n, 4);
+                sibling_ok += 1;
+            }
+            Err(e) => {
+                assert_eq!(i, 1, "non-cancelled op errored: {e}");
+                assert_eq!(e.raw_os_error(), Some(ERROR_OPERATION_ABORTED as i32));
+                middle_aborted = true;
+            }
+        }
+    }
+    assert!(middle_aborted);
+    assert_eq!(sibling_ok, 2);
+}
+
+// --- Step 3.4: stress test ---------------------------------------------
+
+#[test]
+#[ignore]
+fn many_ops_stress() {
+    skip_on_wine!();
+    let (server, client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+    let client_reg = unsafe { poller.register_file(client.as_raw_handle(), 2).unwrap() };
+
+    const ROUNDS: usize = 5_000;
+
+    let mut events = Events::new();
+    let mut payload = [0u8; 4];
+
+    for i in 0..ROUNDS {
+        payload.copy_from_slice(&(i as u32).to_le_bytes());
+
+        let read_op = match server_reg.submit_read(Vec::<u8>::with_capacity(4)) {
+            Submission::Pending(op) => Some(op),
+            Submission::Complete { .. } => None,
+            Submission::Failed { error, .. } => panic!("read failed at i={i}: {error}"),
+        };
+        let write_op = match client_reg.submit_write(payload.to_vec()) {
+            Submission::Pending(op) => Some(op),
+            Submission::Complete { .. } => None,
+            Submission::Failed { error, .. } => panic!("write failed at i={i}: {error}"),
+        };
+
+        if let Some(op) = read_op {
+            common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+            let _ = op.take().0.unwrap();
+        }
+        if let Some(op) = write_op {
+            common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+            let _ = op.take().0.unwrap();
+        }
+    }
+}
+
+/// Step 7c: `RegisteredFile::set_user_key` rebinds the key the
+/// dispatcher emits in subsequent `Event`s. Register with a sentinel,
+/// rebind before the peer writes, then assert the completion event
+/// carries the new key (and `readable: true`).
+#[test]
+fn set_user_key_takes_effect() {
+    skip_on_wine!();
+    const SENTINEL: usize = 0;
+    const KEY: usize = 4242;
+
+    let (server, client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe {
+        poller
+            .register_file(server.as_raw_handle(), SENTINEL)
+            .unwrap()
+    };
+    let client_reg = unsafe { poller.register_file(client.as_raw_handle(), 1).unwrap() };
+
+    let read_op = match server_reg.submit_read(Vec::<u8>::with_capacity(8)) {
+        Submission::Pending(op) => op,
+        other => panic!("expected Pending read on empty pipe, got {other:?}"),
+    };
+
+    // Rebind BEFORE the kernel posts the completion entry.
+    server_reg.set_user_key(KEY);
+
+    // Peer write — for a fresh pipe with a pending overlapped read on
+    // the server, this completes synchronously on the client side and
+    // the server's read finishes asynchronously.
+    match client_reg.submit_write(b"PAYLOAD!".to_vec()) {
+        Submission::Complete { bytes, .. } => assert_eq!(bytes, 8),
+        Submission::Pending(op) => {
+            let mut events = Events::new();
+            common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+            let (res, _) = op.take();
+            let n = res.unwrap();
+            assert_eq!(n, 8);
+        }
+        Submission::Failed { error, .. } => panic!("client write failed: {error}"),
+    }
+
+    let mut events = Events::new();
+    let deadline = Instant::now() + TEST_TIMEOUT;
+    let mut matched = false;
+    while !matched {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            panic!(
+                "timeout waiting for rebound-key event; got {:?}",
+                events.iter().collect::<Vec<_>>()
+            );
+        }
+        poller.wait(&mut events, Some(remaining)).unwrap();
+        matched = events
+            .iter()
+            .any(|e| e.key == KEY && e.readable && !e.writable);
+        // The sentinel must NOT appear in any drained event.
+        assert!(
+            !events.iter().any(|e| e.key == SENTINEL && e.readable),
+            "set_user_key did not take effect: saw sentinel key in {:?}",
+            events.iter().collect::<Vec<_>>()
+        );
+    }
+
+    assert!(read_op.is_complete());
+    let (res, buf) = read_op.take();
+    let n = res.unwrap();
+    assert_eq!(n, 8);
+    let slice = unsafe { std::slice::from_raw_parts(buf.as_ptr(), n) };
+    assert_eq!(slice, b"PAYLOAD!");
+}
+
+// --- Audit: oversized-capacity rejection (H1) -----------------------
+//
+// These tests exercise the `cap > u32::MAX` validation. On 32-bit
+// targets `usize` is 32 bits, so a `usize` value can never exceed
+// `u32::MAX` and the validation branch is unreachable; the tests are
+// therefore restricted to 64-bit (or wider) targets.
+
+#[cfg(target_pointer_width = "64")]
+/// A `StableBufMut` impl that lies about its capacity in order to
+/// exercise the `cap > u32::MAX` validation in `submit_read` /
+/// `submit_write`. The mendacious `capacity()` value is returned
+/// before any syscall, so the `as_mut_ptr()` / `as_ptr()` pointer is
+/// never actually dereferenced through the lying length.
+struct OversizedCapBuf {
+    inner: Vec<u8>,
+}
+
+// SAFETY: `OversizedCapBuf` keeps a stable address while alive (it
+// owns a `Vec<u8>`). It is `Send + 'static`.
+#[cfg(target_pointer_width = "64")]
+unsafe impl polling::os::iocp::StableBuf for OversizedCapBuf {
+    fn as_ptr(&self) -> *const u8 {
+        self.inner.as_ptr()
+    }
+    fn len(&self) -> usize {
+        // Lie about length too so `submit_write` sees an oversized
+        // value. The validation rejects the submission before any
+        // pointer is read for `len` bytes.
+        (u32::MAX as usize) + 1
+    }
+}
+
+// SAFETY: see `StableBuf` impl above. `set_init` is never called by
+// these tests because submissions fail before producing an
+// `OpHandle`.
+#[cfg(target_pointer_width = "64")]
+unsafe impl polling::os::iocp::StableBufMut for OversizedCapBuf {
+    fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.inner.as_mut_ptr()
+    }
+    fn capacity(&self) -> usize {
+        (u32::MAX as usize) + 1
+    }
+    unsafe fn set_init(&mut self, _n: usize) {}
+}
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn submit_read_rejects_oversized_capacity() {
+    skip_on_wine!();
+    let (server, _client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+
+    let buf = OversizedCapBuf { inner: Vec::new() };
+    match server_reg.submit_read(buf) {
+        Submission::Failed { error, .. } => {
+            assert_eq!(
+                error.kind(),
+                std::io::ErrorKind::InvalidInput,
+                "expected InvalidInput, got {error:?}"
+            );
+        }
+        other => panic!("expected Failed for oversized read, got {other:?}"),
+    }
+}
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn submit_write_rejects_oversized_length() {
+    skip_on_wine!();
+    let (_server, client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let client_reg = unsafe { poller.register_file(client.as_raw_handle(), 2).unwrap() };
+
+    let buf = OversizedCapBuf { inner: Vec::new() };
+    match client_reg.submit_write(buf) {
+        Submission::Failed { error, .. } => {
+            assert_eq!(
+                error.kind(),
+                std::io::ErrorKind::InvalidInput,
+                "expected InvalidInput, got {error:?}"
+            );
+        }
+        other => panic!("expected Failed for oversized write, got {other:?}"),
+    }
+}

--- a/tests/file_lifetime.rs
+++ b/tests/file_lifetime.rs
@@ -1,0 +1,212 @@
+//! Lifetime / cleanup tests for the v2 IOCP file-handle submission API.
+//!
+//! Spec: `docs/named-pipe.implement.checklist.md` Step 3.3 / 7.
+//!
+//! These tests verify the buffer- and packet-ownership invariants from
+//! `docs/named-pipe.design.md` §3.4 (kernel-Arc protocol) and
+//! §3.7 (deactivation / drain semantics):
+//!   - dropping an `OpHandle` while the op is pending is **safe** post
+//!     Step 7: the kernel's `Arc` strong ref keeps the allocation
+//!     alive, and the eventual completion path drops the buffer
+//!     cleanly via `OpInner::Drop`.
+//!   - the buffer address is stable across submit / take (Pin invariant);
+//!   - dropping the `Poller` and/or the underlying handle while ops are
+//!     in flight does not corrupt memory.
+//!   - the buffer address is stable across submit / take (Pin invariant);
+//!   - dropping the `Poller` and/or the underlying handle while ops are
+//!     in flight does not corrupt memory.
+
+#![cfg(windows)]
+
+mod common;
+
+use std::os::windows::io::AsRawHandle;
+use std::time::Duration;
+
+use polling::os::iocp::{PollerIocpFileExt, Submission};
+use polling::{Events, Poller};
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[test]
+fn op_outlives_registered_file_clone() {
+    skip_on_wine!();
+    let (server, client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+    let client_reg = unsafe { poller.register_file(client.as_raw_handle(), 2).unwrap() };
+
+    let read_op = match server_reg.submit_read(Vec::<u8>::with_capacity(4)) {
+        Submission::Pending(op) => op,
+        other => panic!("expected Pending, got {other:?}"),
+    };
+
+    drop(server_reg);
+
+    let _ = client_reg.submit_write(b"DATA".to_vec());
+
+    let mut events = Events::new();
+    common::wait_for_handle(&read_op, &poller, &mut events, TEST_TIMEOUT);
+    let (res, buf) = read_op.take();
+    let n = res.unwrap();
+    assert_eq!(n, 4);
+    let slice = unsafe { std::slice::from_raw_parts(buf.as_ptr(), n) };
+    assert_eq!(slice, b"DATA");
+}
+
+#[test]
+fn submit_after_remove_file_errors() {
+    skip_on_wine!();
+    let (server, _client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+
+    server_reg.deactivate();
+
+    match server_reg.submit_read(Vec::<u8>::with_capacity(4)) {
+        Submission::Failed { error, buf } => {
+            assert!(!error.to_string().is_empty(), "error message empty");
+            assert_eq!(buf.capacity(), 4);
+        }
+        other => panic!("expected Failed after deactivate, got {other:?}"),
+    }
+}
+
+#[test]
+fn in_flight_op_completes_after_remove_file() {
+    skip_on_wine!();
+    let (server, client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+    let client_reg = unsafe { poller.register_file(client.as_raw_handle(), 2).unwrap() };
+
+    let read_op = match server_reg.submit_read(Vec::<u8>::with_capacity(4)) {
+        Submission::Pending(op) => op,
+        other => panic!("expected Pending, got {other:?}"),
+    };
+
+    server_reg.deactivate();
+
+    let _ = client_reg.submit_write(b"PING".to_vec());
+
+    let mut events = Events::new();
+    common::wait_for_handle(&read_op, &poller, &mut events, TEST_TIMEOUT);
+    let (res, buf) = read_op.take();
+    let n = res.unwrap();
+    assert_eq!(n, 4);
+    let slice = unsafe { std::slice::from_raw_parts(buf.as_ptr(), n) };
+    assert_eq!(slice, b"PING");
+}
+
+#[test]
+fn drop_pending_op_is_safe() {
+    skip_on_wine!();
+    // Step 7: dropping a pending `OpHandle` is safe. The kernel still
+    // holds one `Arc` strong ref (bumped at submit time), so the
+    // allocation lives on; the eventual completion path drops it and
+    // reclaims the buffer via `OpInner::Drop`. No leak, no UAF.
+    let (server, client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+    let client_reg = unsafe { poller.register_file(client.as_raw_handle(), 2).unwrap() };
+
+    let op = match server_reg.submit_read(Vec::<u8>::with_capacity(4)) {
+        Submission::Pending(op) => op,
+        other => panic!("expected Pending, got {other:?}"),
+    };
+
+    // Drop the user-side handle while still pending.
+    drop(op);
+
+    // Satisfy the read so the kernel posts a completion; the
+    // dispatcher reclaims the kernel's Arc and the buffer is freed.
+    let _ = client_reg.submit_write(b"DATA".to_vec());
+
+    let mut events = Events::new();
+    poller
+        .wait(&mut events, Some(Duration::from_millis(200)))
+        .unwrap();
+}
+
+#[test]
+fn poller_dropped_before_op_completion() {
+    skip_on_wine!();
+    // Submit a pending op, then drop everything (including the
+    // OpHandle while still pending) in a controlled order. Per the
+    // Step 7 redesign, none of these drops may UAF: the kernel still
+    // holds the per-op Arc until `CloseHandle` cancels in-flight ops
+    // and posts their completions, at which point the IOCP port
+    // (still alive via the OpInner back-ref) reclaims them.
+    let (server, _client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+
+    let op = match server_reg.submit_read(Vec::<u8>::with_capacity(4)) {
+        Submission::Pending(op) => op,
+        other => panic!("expected Pending, got {other:?}"),
+    };
+
+    drop(server_reg);
+    drop(op);
+    drop(server); // closes the kernel handle; cancels in-flight ops.
+    drop(poller); // dispatcher gone; remaining kernel Arc refs leak the
+                  //   per-op allocation, but no UAF can occur because
+                  //   the OpInner back-reference holds the IOCP port.
+}
+
+#[test]
+fn buf_addr_stable_across_submit() {
+    skip_on_wine!();
+    let (server, client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+    let client_reg = unsafe { poller.register_file(client.as_raw_handle(), 2).unwrap() };
+
+    let payload = b"PING".to_vec();
+    let original_ptr = payload.as_ptr();
+
+    let returned_ptr = match client_reg.submit_write(payload) {
+        Submission::Complete { buf, .. } => buf.as_ptr(),
+        Submission::Pending(op) => {
+            let mut events = Events::new();
+            common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+            let (res, buf) = op.take();
+            let _ = res.unwrap();
+            buf.as_ptr()
+        }
+        Submission::Failed { error, .. } => panic!("write failed: {error}"),
+    };
+
+    assert_eq!(
+        original_ptr, returned_ptr,
+        "buffer heap address changed across submit"
+    );
+
+    // Drain the matching read so the pipe completion isn't left
+    // dangling.
+    let _ = server_reg.submit_read(Vec::<u8>::with_capacity(4));
+    drop(client);
+    let _ = poller.wait(&mut Events::new(), Some(Duration::from_millis(50)));
+}
+
+#[test]
+#[ignore]
+fn vec_grown_after_submit_is_safe() {
+    skip_on_wine!();
+    // The v2 API takes the buffer by value, so the user has no handle
+    // to the `Vec` between `submit_*` and `OpHandle::take`. It
+    // is impossible to grow / mutate the buffer mid-flight through
+    // safe Rust, which is exactly the invariant the design intends.
+    //
+    // ```compile_fail
+    // # use polling::os::iocp::{PollerIocpFileExt, Submission};
+    // # use polling::Poller;
+    // # use std::os::windows::io::AsRawHandle;
+    // # let (s, _c) = polling_test_common::pipe();
+    // # let p = Poller::new().unwrap();
+    // # let r = unsafe { p.register_file(s.as_raw_handle()).unwrap() };
+    // let mut buf = Vec::<u8>::with_capacity(4);
+    // let _ = r.submit_write(buf);
+    // buf.push(0); // ERROR: `buf` was moved into `submit_write`
+    // ```
+}

--- a/tests/windows_overlapped.rs
+++ b/tests/windows_overlapped.rs
@@ -1,0 +1,475 @@
+//! Windows IOCP file-handle tests for the `RegisteredFile` submission API.
+//!
+//! Spec: `docs/named-pipe.implement.checklist.md` Step 4 + 7 +
+//! `docs/named-pipe.design.md` §7.
+//!
+//! Step 7 of the implementation deletes `FileCompletion` entirely; the
+//! `OpHandle` returned from `submit_*` now owns the completion
+//! lifecycle (`is_complete` / `take`). Step 7b drives those checks
+//! by emitting a normal `Event { key, readable, writable }` per
+//! completion, so the dispatcher integrates cleanly with reactors.
+
+#![cfg(windows)]
+
+mod common;
+
+use std::io;
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+use std::time::Duration;
+
+use polling::os::iocp::{PollerIocpFileExt, Submission};
+use polling::{Events, Poller};
+
+use windows_sys::Win32::{Foundation as wf, Storage::FileSystem as wfs};
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[test]
+fn win32_file_io() {
+    skip_on_wine!();
+    let poller = Poller::new().unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("test.txt");
+    let fname = file_path
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+
+    let file_handle = unsafe {
+        let raw_handle = wfs::CreateFileW(
+            fname.as_ptr(),
+            wf::GENERIC_WRITE | wf::GENERIC_READ,
+            0,
+            std::ptr::null_mut(),
+            wfs::CREATE_ALWAYS,
+            wfs::FILE_FLAG_OVERLAPPED,
+            std::ptr::null_mut(),
+        );
+        if raw_handle == wf::INVALID_HANDLE_VALUE {
+            panic!("CreateFileW failed: {}", io::Error::last_os_error());
+        }
+        OwnedHandle::from_raw_handle(raw_handle as _)
+    };
+
+    let reg = unsafe {
+        poller
+            .register_file(file_handle.as_raw_handle(), 1)
+            .unwrap()
+    };
+
+    let input_text = "Now is the time for all good men to come to the aid of their party";
+    let payload = input_text.as_bytes().to_vec();
+    let payload_len = payload.len();
+
+    let written = match reg.submit_write(payload) {
+        Submission::Complete { bytes, .. } => bytes,
+        Submission::Pending(op) => {
+            let mut events = Events::new();
+            common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+            op.take().0.unwrap()
+        }
+        Submission::Failed { error, .. } => {
+            if std::env::var("WINELOADER").is_ok()
+                || std::env::var("WINE").is_ok()
+                || std::env::var("WINEPREFIX").is_ok()
+            {
+                println!("Skipping under Wine: {error}");
+                return;
+            }
+            panic!("write failed: {error}");
+        }
+    };
+    assert_eq!(written, payload_len);
+
+    drop(reg);
+    drop(file_handle);
+
+    let file_handle = unsafe {
+        let raw_handle = wfs::CreateFileW(
+            fname.as_ptr(),
+            wf::GENERIC_READ | wf::GENERIC_WRITE,
+            0,
+            std::ptr::null_mut(),
+            wfs::OPEN_EXISTING,
+            wfs::FILE_FLAG_OVERLAPPED,
+            std::ptr::null_mut(),
+        );
+        if raw_handle == wf::INVALID_HANDLE_VALUE {
+            panic!("CreateFileW failed: {}", io::Error::last_os_error());
+        }
+        OwnedHandle::from_raw_handle(raw_handle as _)
+    };
+
+    let reg = unsafe {
+        poller
+            .register_file(file_handle.as_raw_handle(), 1)
+            .unwrap()
+    };
+    let buf = Vec::<u8>::with_capacity(1024);
+
+    let (n, buf) = match reg.submit_read(buf) {
+        Submission::Complete { bytes, buf } => (bytes, buf),
+        Submission::Pending(op) => {
+            let mut events = Events::new();
+            common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+            {
+                let (r, b) = op.take();
+                (r.unwrap(), b)
+            }
+        }
+        Submission::Failed { error, .. } => panic!("read failed: {error}"),
+    };
+    assert_eq!(n, payload_len);
+    let slice = unsafe { std::slice::from_raw_parts(buf.as_ptr(), n) };
+    assert_eq!(slice, input_text.as_bytes());
+}
+
+#[test]
+fn writable_after_register() {
+    skip_on_wine!();
+    {
+        let name = format!(r"\\.\pipe\my-pipe-{}", fastrand::u64(..));
+        let client = common::client(&name);
+        assert_eq!(client.err().unwrap().kind(), io::ErrorKind::NotFound);
+    }
+
+    let (server, client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+    let _client_reg = unsafe { poller.register_file(client.as_raw_handle(), 2).unwrap() };
+
+    match server_reg.submit_connect_named_pipe() {
+        Submission::Complete { bytes, .. } => assert_eq!(bytes, 0),
+        other => panic!("expected sync Complete (pipe pre-connected), got {other:?}"),
+    }
+
+    let mut events = Events::new();
+    poller
+        .wait(&mut events, Some(Duration::from_millis(10)))
+        .unwrap();
+    assert_eq!(events.iter().count(), 0);
+
+    let (server2, name) = common::server();
+    let poller2 = Poller::new().unwrap();
+    let _server2_reg = unsafe { poller2.register_file(server2.as_raw_handle(), 3).unwrap() };
+    let _client2 = common::client(&name).unwrap();
+
+    let mut events = Events::new();
+    poller2
+        .wait(&mut events, Some(Duration::from_millis(10)))
+        .unwrap();
+    assert_eq!(events.iter().count(), 0);
+}
+
+#[test]
+fn write_then_read() {
+    skip_on_wine!();
+    let (server, client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+    let client_reg = unsafe { poller.register_file(client.as_raw_handle(), 2).unwrap() };
+
+    match client_reg.submit_write(b"1234".to_vec()) {
+        Submission::Complete { bytes, .. } => assert_eq!(bytes, 4),
+        Submission::Pending(op) => {
+            let mut events = Events::new();
+            common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+            let (res, _) = op.take();
+            let n = res.unwrap();
+            assert_eq!(n, 4);
+        }
+        Submission::Failed { error, .. } => panic!("write failed: {error}"),
+    }
+
+    let buf = Vec::<u8>::with_capacity(10);
+    let (n, buf) = match server_reg.submit_read(buf) {
+        Submission::Complete { bytes, buf } => (bytes, buf),
+        Submission::Pending(op) => {
+            let mut events = Events::new();
+            common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+            {
+                let (r, b) = op.take();
+                (r.unwrap(), b)
+            }
+        }
+        Submission::Failed { error, .. } => panic!("read failed: {error}"),
+    };
+    assert_eq!(n, 4);
+    let slice = unsafe { std::slice::from_raw_parts(buf.as_ptr(), n) };
+    assert_eq!(slice, b"1234");
+}
+
+#[test]
+fn close_before_read_complete() {
+    skip_on_wine!();
+    let (server, _name) = common::server();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+
+    let op = match server_reg.submit_connect_named_pipe() {
+        Submission::Pending(op) => op,
+        Submission::Complete { .. } => {
+            panic!("expected Pending for connect on a fresh server with no client");
+        }
+        Submission::Failed { error, .. } => panic!("connect submission failed: {error}"),
+    };
+
+    drop(server_reg);
+    drop(server);
+
+    let mut events = Events::new();
+    common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+
+    match op.take() {
+        (Ok(0), _) => {}
+        (Ok(n), _) => panic!("unexpected success with {n} bytes"),
+        (Err(e), _) => {
+            let code = e.raw_os_error().unwrap_or(0);
+            assert!(
+                matches!(
+                    code as u32,
+                    wf::ERROR_OPERATION_ABORTED
+                        | wf::ERROR_BROKEN_PIPE
+                        | wf::ERROR_INVALID_HANDLE
+                        | wf::ERROR_PIPE_NOT_CONNECTED
+                ),
+                "unexpected error after handle close: {e} (code {code})"
+            );
+        }
+    }
+}
+
+#[test]
+fn connect_before_client() {
+    skip_on_wine!();
+    let (server, name) = common::server();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+
+    let mut events = Events::new();
+    poller
+        .wait(&mut events, Some(Duration::from_millis(10)))
+        .unwrap();
+    assert_eq!(events.iter().count(), 0);
+
+    let op = match server_reg.submit_connect_named_pipe() {
+        Submission::Pending(op) => op,
+        other => panic!("expected Pending, got {other:?}"),
+    };
+
+    let client = common::client(&name).unwrap();
+    let _client_reg = unsafe { poller.register_file(client.as_raw_handle(), 2).unwrap() };
+
+    let mut events = Events::new();
+    common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+    let (res, _) = op.take();
+    let bytes = res.unwrap();
+    assert_eq!(bytes, 0);
+}
+
+#[test]
+fn write_disconnected() {
+    skip_on_wine!();
+    let (server, client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+    let _client_reg = unsafe { poller.register_file(client.as_raw_handle(), 2).unwrap() };
+
+    drop(client);
+
+    let mut events = Events::new();
+    poller
+        .wait(&mut events, Some(Duration::from_millis(10)))
+        .unwrap();
+    assert_eq!(events.iter().count(), 0);
+
+    match server_reg.submit_write(b"1234".to_vec()) {
+        Submission::Failed { error, buf } => {
+            let code = error.raw_os_error().map(|c| c as u32).unwrap_or(0);
+            assert!(
+                matches!(
+                    code,
+                    wf::ERROR_NO_DATA | wf::ERROR_PIPE_NOT_CONNECTED | wf::ERROR_BROKEN_PIPE
+                ),
+                "unexpected error: {error} (code {code})"
+            );
+            assert_eq!(buf.len(), 4);
+        }
+        other => panic!("expected Failed for write to disconnected pipe, got {other:?}"),
+    }
+
+    let mut events = Events::new();
+    poller
+        .wait(&mut events, Some(Duration::from_millis(10)))
+        .unwrap();
+    assert_eq!(events.iter().count(), 0);
+}
+
+#[test]
+fn drop_writer_drain() {
+    skip_on_wine!();
+    let (server, client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+    let client_reg = unsafe { poller.register_file(client.as_raw_handle(), 2).unwrap() };
+
+    match client_reg.submit_write(b"1234".to_vec()) {
+        Submission::Complete { bytes, .. } => assert_eq!(bytes, 4),
+        Submission::Pending(op) => {
+            let mut events = Events::new();
+            common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+            let (res, _) = op.take();
+            let n = res.unwrap();
+            assert_eq!(n, 4);
+        }
+        Submission::Failed { error, .. } => panic!("write failed: {error}"),
+    }
+
+    drop(client_reg);
+    drop(client);
+
+    let buf = Vec::<u8>::with_capacity(10);
+    let (n, buf) = match server_reg.submit_read(buf) {
+        Submission::Complete { bytes, buf } => (bytes, buf),
+        Submission::Pending(op) => {
+            let mut events = Events::new();
+            common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+            {
+                let (r, b) = op.take();
+                (r.unwrap(), b)
+            }
+        }
+        Submission::Failed { error, .. } => panic!("read failed: {error}"),
+    };
+    assert_eq!(n, 4);
+    let slice = unsafe { std::slice::from_raw_parts(buf.as_ptr(), n) };
+    assert_eq!(slice, b"1234");
+}
+
+#[test]
+fn connect_twice() {
+    skip_on_wine!();
+    let (server, name) = common::server();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+
+    let op = match server_reg.submit_connect_named_pipe() {
+        Submission::Pending(op) => op,
+        other => panic!("expected Pending, got {other:?}"),
+    };
+
+    let c1 = common::client(&name).unwrap();
+    let _c1_reg = unsafe { poller.register_file(c1.as_raw_handle(), 4).unwrap() };
+
+    let mut events = Events::new();
+    common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+    let (res, _) = op.take();
+    let bytes = res.unwrap();
+    assert_eq!(bytes, 0);
+
+    drop(c1);
+
+    match server_reg.submit_connect_named_pipe() {
+        Submission::Failed { error, .. } => {
+            let code = error.raw_os_error().map(|c| c as u32).unwrap_or(0);
+            assert!(
+                matches!(
+                    code,
+                    wf::ERROR_NO_DATA
+                        | wf::ERROR_PIPE_CONNECTED
+                        | wf::ERROR_BROKEN_PIPE
+                        | wf::ERROR_PIPE_NOT_CONNECTED
+                ),
+                "unexpected error: {error} (code {code})"
+            );
+        }
+        Submission::Complete { .. } => {}
+        Submission::Pending(op) => {
+            let _ = op.cancel();
+            let mut events = Events::new();
+            common::wait_for_handle(&op, &poller, &mut events, TEST_TIMEOUT);
+            let _ = op.take();
+        }
+    }
+}
+
+#[test]
+fn remove_file_before_add_file() {
+    skip_on_wine!();
+    let (server, _name) = common::server();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe { poller.register_file(server.as_raw_handle(), 1).unwrap() };
+
+    server_reg.deactivate();
+
+    match server_reg.submit_read(Vec::<u8>::with_capacity(4)) {
+        Submission::Failed { buf, .. } => assert_eq!(buf.capacity(), 4),
+        other => panic!("expected Failed after deactivate, got {other:?}"),
+    }
+    match server_reg.submit_write(b"x".to_vec()) {
+        Submission::Failed { buf, .. } => assert_eq!(buf, b"x"),
+        other => panic!("expected Failed after deactivate, got {other:?}"),
+    }
+}
+
+#[test]
+fn add_file_different_poll() {
+    skip_on_wine!();
+    let (server, _) = common::server();
+    let poller1 = Poller::new().unwrap();
+    let poller2 = Poller::new().unwrap();
+
+    let _reg1 = unsafe { poller1.register_file(server.as_raw_handle(), 1).unwrap() };
+    let result = unsafe { poller2.register_file(server.as_raw_handle(), 1) };
+    assert!(
+        result.is_err(),
+        "second register_file must fail when handle already bound"
+    );
+}
+
+/// Step 7b: the dispatcher emits a normal `Event { key, readable,
+/// writable }` per file-op completion, mirroring the registered key
+/// and the op's direction. A `submit_read` completion must surface as
+/// `(key, readable: true, writable: false)`.
+#[test]
+fn read_completion_emits_event_with_key_and_direction() {
+    skip_on_wine!();
+    const SERVER_KEY: usize = 7;
+    const CLIENT_KEY: usize = 8;
+    let (server, client) = common::pipe();
+    let poller = Poller::new().unwrap();
+    let server_reg = unsafe {
+        poller
+            .register_file(server.as_raw_handle(), SERVER_KEY)
+            .unwrap()
+    };
+    let _client_reg = unsafe {
+        poller
+            .register_file(client.as_raw_handle(), CLIENT_KEY)
+            .unwrap()
+    };
+
+    let op = match server_reg.submit_read(Vec::<u8>::with_capacity(4)) {
+        Submission::Pending(op) => op,
+        other => panic!("expected Pending, got {other:?}"),
+    };
+
+    op.cancel().unwrap();
+
+    let mut events = Events::new();
+    poller.wait(&mut events, Some(TEST_TIMEOUT)).unwrap();
+
+    let matched = events
+        .iter()
+        .any(|e| e.key == SERVER_KEY && e.readable && !e.writable);
+    assert!(
+        matched,
+        "expected an Event {{ key: {SERVER_KEY}, readable: true, writable: false }}, got {:?}",
+        events.iter().collect::<Vec<_>>()
+    );
+    assert!(op.is_complete());
+    let _ = op.take();
+}


### PR DESCRIPTION
Closes https://github.com/smol-rs/polling/issues/97

This is an implementation to support Windows file handle overlapped I/O. The basic idea is:

1. Add an File struct in PacketInner. The File struct have read and write OVERLAPPED struct. The read and write struct address will exposed to callers. The caller use read and write overlapped pointer as parameter for ReadFile/WriteFile operation.
2. IOCP completion events receive read and write address which will be converted back to Packet for updating events
3. New PollerIocpFileExt trait which has add_file and remove_file API to extend file functionality.

