### PR TITLE
Always use `ErrorKind::NotFound` for `Poller::delete` of unknown source

### DIFF
--- a/src/iocp/mod.rs
+++ b/src/iocp/mod.rs
@@ -295,8 +295,8 @@ impl Poller {
             match sources.remove(&socket.as_raw_socket()) {
                 Some(s) => s,
                 None => {
-                    // If the source has already been removed, then we can just return.
-                    return Ok(());
+                    // If the source wasn't recognized then we must return a NotFound error.
+                    return Err(io::ErrorKind::NotFound.into());
                 }
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -670,6 +670,10 @@ impl Poller {
     /// Unlike [`add()`][`Poller::add()`], this method only removes the file descriptor or
     /// socket from the poller without putting it back into blocking mode.
     ///
+    /// If the given source is not known to the poller then this is guaranteed to fail
+    /// with [`std::io::ErrorKind::NotFound`]. That particular error kind is never
+    /// returned in any other situation.
+    ///
     /// # Examples
     ///
     /// ```

--- a/src/port.rs
+++ b/src/port.rs
@@ -98,14 +98,7 @@ impl Poller {
         #[cfg(feature = "tracing")]
         let _enter = span.enter();
 
-        let result = unsafe { port::dissociate_fd(&self.port_fd, fd) };
-        if let Err(e) = result {
-            match e {
-                rustix::io::Errno::NOENT => return Ok(()),
-                _ => return Err(e.into()),
-            }
-        }
-
+        unsafe { port::dissociate_fd(&self.port_fd, fd) }?;
         Ok(())
     }
 

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -81,6 +81,22 @@ fn insert_twice() {
     poller.delete(&read).unwrap();
 }
 
+#[test]
+fn delete_unrecognized() {
+    let (read, _) = tcp_pair().unwrap();
+    let read = Arc::new(read);
+
+    let poller = Poller::new().unwrap();
+    match poller.delete(&read) {
+        Ok(_) => panic!("delete of unregistered source succeeded"),
+        Err(e) => assert_eq!(
+            e.kind(),
+            io::ErrorKind::NotFound,
+            "wrong error kind for delete of unregistered source",
+        ),
+    }
+}
+
 /// Test that calling `wait` appends events, as [documented], rather than
 /// overwriting them.
 ///


### PR DESCRIPTION
The IOCP and Event Port implementations were previously inconsistent with the others in how their `delete` implementations reacted to being asked to delete a source that wasn't previously registered with `add`: they would return `Ok(())` without making any changes in that case, whereas the other implementations all return an `ErrorKind::NotFound` error.

Just to improve the consistency of behavior between the implementations, those two backends will now also return `ErrorKind::NotFound` errors. This should not change the behavior of any correct program, but might make it easier to catch incorrect usage when testing on a system that uses one of these two backends.

This closes https://github.com/smol-rs/polling/issues/259. While writing this I realized I had incorrectly diagnosed the problem I was having as being caused by this inconsistency, but nonetheless it was still inconsistent.
