### PR TITLE
Fix issues in CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,7 @@ env:
 freebsd_task:
   name: test ($TARGET)
   freebsd_instance:
-    image_family: freebsd-13-4
+    image_family: freebsd-14-3
   matrix:
     - env:
         TARGET: x86_64-unknown-freebsd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,9 +140,11 @@ jobs:
     - name: Check haiku
       if: startsWith(matrix.rust, 'nightly') && startsWith(matrix.os, 'ubuntu')
       run: cargo check -Z build-std --target x86_64-unknown-haiku
-    - name: Check vita
-      if: startsWith(matrix.rust, 'nightly') && startsWith(matrix.os, 'ubuntu')
-      run: cargo check -Z build-std --target armv7-sony-vita-newlibeabihf
+    # Vita check is broken until this issue is fixed:
+    # https://github.com/bytecodealliance/rustix/issues/1576
+    #- name: Check vita
+    #  if: startsWith(matrix.rust, 'nightly') && startsWith(matrix.os, 'ubuntu')
+    #  run: cargo check -Z build-std --target armv7-sony-vita-newlibeabihf
     - name: Check ESP-IDF
       if: startsWith(matrix.rust, 'nightly') && startsWith(matrix.os, 'ubuntu')
       run: cargo check -Z build-std --target riscv32imc-esp-espidf


### PR DESCRIPTION
- Move to the newest FreeBSD image available in Cirrus.
- Temporarily disable PS-Vita tests.
