### PR TITLE
Replace pipe_with calls on AIX same as haiku,nto

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -662,7 +662,7 @@ mod notify {
     use rustix::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
     use rustix::fs::{fcntl_getfl, fcntl_setfl, OFlags};
     use rustix::io::{fcntl_getfd, fcntl_setfd, read, write, FdFlags};
-    #[cfg(not(any(target_os = "haiku", target_os = "nto")))]
+    #[cfg(not(any(target_os = "haiku", target_os = "nto", target_os = "aix")))]
     use rustix::pipe::pipe_with;
     use rustix::pipe::{pipe, PipeFlags};
 
@@ -692,10 +692,10 @@ mod notify {
                 io::Result::Ok((read_pipe, write_pipe))
             };
 
-            #[cfg(not(any(target_os = "haiku", target_os = "nto")))]
+            #[cfg(not(any(target_os = "haiku", target_os = "nto", target_os = "aix")))]
             let (read_pipe, write_pipe) = pipe_with(PipeFlags::CLOEXEC).or_else(fallback_pipe)?;
 
-            #[cfg(any(target_os = "haiku", target_os = "nto"))]
+            #[cfg(any(target_os = "haiku", target_os = "nto", target_os = "aix"))]
             let (read_pipe, write_pipe) = fallback_pipe(PipeFlags::CLOEXEC)?;
 
             // Put the reading side into non-blocking mode.


### PR DESCRIPTION
AIX doesn't support `pipe_with`, we can use the same workaround as haiku and nto