### PR TITLE
fix(kqueue): preserve EV_CLEAR on EVFILT_USER notify and reset flag on EINTR

### DIFF
--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -470,14 +470,17 @@ mod notify {
 
         /// Notifies the `Poller`.
         pub(super) fn notify(&self, poller: &Poller) -> io::Result<()> {
-            // Trigger the EVFILT_USER event.
+            // Trigger the EVFILT_USER event.  EV_CLEAR must be
+            // preserved so the event auto-resets after delivery;
+            // without it EV_ADD would switch the filter to
+            // level-triggered mode and subsequent waits would spin.
             poller.submit_changes([kqueue::Event::new(
                 kqueue::EventFilter::User {
                     ident: 0,
                     flags: kqueue::UserFlags::TRIGGER,
                     user_flags: kqueue::UserDefinedFlags::new(0),
                 },
-                kqueue::EventFlags::ADD | kqueue::EventFlags::RECEIPT,
+                kqueue::EventFlags::ADD | kqueue::EventFlags::RECEIPT | kqueue::EventFlags::CLEAR,
                 crate::NOTIFY_KEY as _,
             )])?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -759,6 +759,11 @@ impl Poller {
                     // If the wait was interrupted by a signal, clear events and try again.
                     if e.kind() == io::ErrorKind::Interrupted {
                         events.clear();
+                        // Reset the notification flag so a concurrent
+                        // notify() call whose EVFILT_USER event was
+                        // consumed by the interrupted kevent() can
+                        // re-trigger.
+                        self.notified.swap(false, Ordering::SeqCst);
                         continue;
                     } else {
                         return Err(e);


### PR DESCRIPTION
Two bugs in the kqueue EVFILT_USER notification path:

1. **`notify()` drops `EV_CLEAR`**: The trigger changelist uses `EV_ADD` without `EV_CLEAR`. Since the filter was originally registered with `EV_CLEAR` (edge-triggered auto-reset), the `EV_ADD` in `notify()` silently switches it to level-triggered mode. After the first notification, every subsequent `kevent()` wait returns the stale event immediately, causing a busy loop.

2. **EINTR swallows concurrent notification**: When `kevent()` returns `EINTR`, the interrupted call may have already consumed the `EVFILT_USER` event from a concurrent `notify()`. The retry loop clears events but does not reset the `notified` flag, so `notify()` believes its event is still pending and skips re-triggering. The waiter never wakes.